### PR TITLE
fix: toc container

### DIFF
--- a/style.css
+++ b/style.css
@@ -7240,11 +7240,10 @@ li>ol {
 
 .toc-container {
     z-index: 98;
-    width: 200px;
-    height: 100%;
+    /* height: 100%; */
     background-color: rgba(255, 255, 255, 0);
     transform: translateX(0);
-    right: calc((100% - 1040px - 250px)/ 2);
+    right: calc((100% - 860px - 20px)/4);
     position: absolute !important;
     top: 480px;
     position: absolute;


### PR DESCRIPTION
目前的计算样式会使toc-container在屏幕宽度接近1080px时超过body宽度导致越界

pr中新改进的样式能修复这一问题，**但是在第一次渲染时显示位置会偏左（随后会自动移动到正确的位置），造成不太好的体验**

暂且放在这等一个更好的方案