### PR TITLE
permission_callback required

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -29,46 +29,57 @@ add_action('rest_api_init', function () {
     register_rest_route('sakura/v1', '/image/upload', array(
         'methods' => 'POST',
         'callback' => 'upload_image',
+        'permission_callback'=>'__return_true'
     ));
     register_rest_route('sakura/v1', '/cache_search/json', array(
         'methods' => 'GET',
         'callback' => 'cache_search_json',
+        'permission_callback'=>'__return_true'
     ));
     register_rest_route('sakura/v1', '/image/cover', array(
         'methods' => 'GET',
         'callback' => 'cover_gallery',
+        'permission_callback'=>'__return_true'
     ));
     register_rest_route('sakura/v1', '/image/feature', array(
         'methods' => 'GET',
         'callback' => 'feature_gallery',
+        'permission_callback'=>'__return_true'
     ));
     register_rest_route('sakura/v1', '/database/update', array(
         'methods' => 'GET',
         'callback' => 'update_database',
+        'permission_callback'=>'__return_true'
     ));
     register_rest_route('sakura/v1', '/qqinfo/json', array(
         'methods' => 'GET',
         'callback' => 'get_qq_info',
+        'permission_callback'=>'__return_true'
     ));
     register_rest_route('sakura/v1', '/qqinfo/avatar', array(
         'methods' => 'GET',
         'callback' => 'get_qq_avatar',
+        'permission_callback'=>'__return_true'
     ));
     register_rest_route('sakura/v1', '/bangumi/bilibili', array(
         'methods' => 'POST',
         'callback' => 'bgm_bilibili',
+        'permission_callback'=>'__return_true'
     ));
 	register_rest_route('sakura/v1', '/favlist/bilibili', array(
 		'methods' => 'POST',
 		'callback' => 'favlist_bilibili',
+        'permission_callback'=>'__return_true'
 	));
     register_rest_route('sakura/v1', '/meting/aplayer', array(
         'methods' => 'GET',
         'callback' => 'meting_aplayer',
+        'permission_callback'=>'__return_true'
     ));
     register_rest_route('sakura/v1', '/captcha/create', array(
         'methods' => 'GET',
         'callback' => 'create_CAPTCHA',
+        'permission_callback'=>'__return_true'
     ));
 });
 

--- a/inc/api.php
+++ b/inc/api.php
@@ -46,11 +46,11 @@ add_action('rest_api_init', function () {
         'callback' => 'feature_gallery',
         'permission_callback'=>'__return_true'
     ));
-    register_rest_route('sakura/v1', '/database/update', array(
-        'methods' => 'GET',
-        'callback' => 'update_database',
-        'permission_callback'=>'__return_true'
-    ));
+    // register_rest_route('sakura/v1', '/database/update', array(
+    //     'methods' => 'GET',
+    //     'callback' => 'update_database',
+    //     'permission_callback'=>'__return_true'
+    // ));
     register_rest_route('sakura/v1', '/qqinfo/json', array(
         'methods' => 'GET',
         'callback' => 'get_qq_info',
@@ -191,15 +191,15 @@ function feature_gallery() {
  * update database rest api
  * @rest api接口路径：https://sakura.2heng.xin/wp-json/sakura/v1/database/update
  */
-function update_database() {
-    if (iro_opt('random_graphs_options') == "webp_optimization") {
-        $output = Cache::update_database();
-        $result = new WP_REST_Response($output, 200);
-        return $result;
-    } else {
-        return new WP_REST_Response("Invalid access", 200);
-    }
-}
+// function update_database() {
+//     if (iro_opt('random_graphs_options') == "webp_optimization") {
+//         $output = Cache::update_database();
+//         $result = new WP_REST_Response($output, 200);
+//         return $result;
+//     } else {
+//         return new WP_REST_Response("Invalid access", 200);
+//     }
+// }
 
 /*
  * 定制实时搜索 rest api

--- a/inc/classes/Cache.php
+++ b/inc/classes/Cache.php
@@ -75,56 +75,56 @@ EOS;
     }
 
 
-    public static function update_database() {
-        global $wpdb;
-        $sakura_table_name = $wpdb->base_prefix . 'sakurairo';
-        $img_domain = iro_opt('random_graphs_link') ? iro_opt('random_graphs_link') : get_template_directory();
-        $manifest = file_get_contents($img_domain . "/manifest/manifest.json");
-        if(iro_opt('random_graphs_mts')){
-            $manifest_mobile = file_get_contents($img_domain . "/manifest/manifest_mobile.json");
-            if($manifest && $manifest_mobile){
-                $manifest = array(
-                    "mate_key" => "manifest_json",
-                    "mate_value" => $manifest
-                );
-                $manifest_mobile = array(
-                    "mate_key" => "mobile_manifest_json",
-                    "mate_value" => $manifest_mobile
-                );
-                $time = array(
-                    "mate_key" => "json_time",
-                    "mate_value" => date("Y-m-d H:i:s", time())
-                );
+    // public static function update_database() {
+    //     global $wpdb;
+    //     $sakura_table_name = $wpdb->base_prefix . 'sakurairo';
+    //     $img_domain = iro_opt('random_graphs_link') ? iro_opt('random_graphs_link') : get_template_directory();
+    //     $manifest = file_get_contents($img_domain . "/manifest/manifest.json");
+    //     if(iro_opt('random_graphs_mts')){
+    //         $manifest_mobile = file_get_contents($img_domain . "/manifest/manifest_mobile.json");
+    //         if($manifest && $manifest_mobile){
+    //             $manifest = array(
+    //                 "mate_key" => "manifest_json",
+    //                 "mate_value" => $manifest
+    //             );
+    //             $manifest_mobile = array(
+    //                 "mate_key" => "mobile_manifest_json",
+    //                 "mate_value" => $manifest_mobile
+    //             );
+    //             $time = array(
+    //                 "mate_key" => "json_time",
+    //                 "mate_value" => date("Y-m-d H:i:s", time())
+    //             );
     
-                $wpdb->query("DELETE FROM  $sakura_table_name WHERE `mate_key` ='manifest_json'");
-                $wpdb->query("DELETE FROM  $sakura_table_name WHERE `mate_key` ='mobile_manifest_json'");
-                $wpdb->query("DELETE FROM  $sakura_table_name WHERE `mate_key` ='json_time'");
-                $wpdb->insert($sakura_table_name, $manifest);
-                $wpdb->insert($sakura_table_name, $manifest_mobile);
-                $wpdb->insert($sakura_table_name, $time);
-                $output = "manifest.json&&mainfest_mobile.json has been stored into database.";
-            } else {
-                $output = "manifest.json or mainfest_mobile.json not found, please ensure your url ($img_domain) is corrent.";
-            }
-            }
-        elseif ($manifest) {
-            $manifest = array(
-                "mate_key" => "manifest_json",
-                "mate_value" => $manifest
-            );
-            $time = array(
-                "mate_key" => "json_time",
-                "mate_value" => date("Y-m-d H:i:s", time())
-            );
+    //             $wpdb->query("DELETE FROM  $sakura_table_name WHERE `mate_key` ='manifest_json'");
+    //             $wpdb->query("DELETE FROM  $sakura_table_name WHERE `mate_key` ='mobile_manifest_json'");
+    //             $wpdb->query("DELETE FROM  $sakura_table_name WHERE `mate_key` ='json_time'");
+    //             $wpdb->insert($sakura_table_name, $manifest);
+    //             $wpdb->insert($sakura_table_name, $manifest_mobile);
+    //             $wpdb->insert($sakura_table_name, $time);
+    //             $output = "manifest.json&&mainfest_mobile.json has been stored into database.";
+    //         } else {
+    //             $output = "manifest.json or mainfest_mobile.json not found, please ensure your url ($img_domain) is corrent.";
+    //         }
+    //         }
+    //     elseif ($manifest) {
+    //         $manifest = array(
+    //             "mate_key" => "manifest_json",
+    //             "mate_value" => $manifest
+    //         );
+    //         $time = array(
+    //             "mate_key" => "json_time",
+    //             "mate_value" => date("Y-m-d H:i:s", time())
+    //         );
 
-            $wpdb->query("DELETE FROM  $sakura_table_name WHERE `mate_key` ='manifest_json'");
-            $wpdb->query("DELETE FROM  $sakura_table_name WHERE `mate_key` ='json_time'");
-            $wpdb->insert($sakura_table_name, $manifest);
-            $wpdb->insert($sakura_table_name, $time);
-            $output = "manifest.json has been stored into database.";
-        } else {
-            $output = "manifest.json not found, please ensure your url ($img_domain) is corrent.";
-        }
-        return $output;
-    }
+    //         $wpdb->query("DELETE FROM  $sakura_table_name WHERE `mate_key` ='manifest_json'");
+    //         $wpdb->query("DELETE FROM  $sakura_table_name WHERE `mate_key` ='json_time'");
+    //         $wpdb->insert($sakura_table_name, $manifest);
+    //         $wpdb->insert($sakura_table_name, $time);
+    //         $output = "manifest.json has been stored into database.";
+    //     } else {
+    //         $output = "manifest.json not found, please ensure your url ($img_domain) is corrent.";
+    //     }
+    //     return $output;
+    // }
 }


### PR DESCRIPTION
[自WordPress 5.5](https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#permissions-callback
)，被要求在调用```register_rest_route()```时提供

鉴于主题目前大部分API都是公开的，暂时加上了```'__return_true'```
但是某些API或许可以趁这个机会加上鉴权限制，例如：```update_database()```或许应当只被管理员调用

大家有空看看