### PR TITLE
fix/Issue-530: Fixed Frontend Localization: Category showing in Chinese

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -285,7 +285,7 @@ function sakura_scripts()
             '很高兴你翻到这里，但是真的没有了...' => __("Glad you come, but we've got nothing left.", 'sakurairo'),
             "文章" => __("Post", 'sakurairo'),
             "标签" => __("Tag", 'sakurairo'),
-            "目录" => __("Category", 'sakurairo'),
+            "分类" => __("Category", 'sakurairo'),
             "页面" => __("Page", 'sakurairo'),
             "评论" => __("Comment", 'sakurairo'),
             "已暂停..." => __("Paused...", 'sakurairo'),


### PR DESCRIPTION
[Original Ticket](https://github.com/mirai-mamori/Sakurairo/issues/530)  #530 
- Attempting to fix Frontend Localization: Category showing in Chinese since frontend script get_locale() function mis-matched .pot file msgid.
- Before applying: [Image](https://user-images.githubusercontent.com/43423211/167981419-b8d7cec9-dd9e-4459-ad09-f7999dd6dee4.png)
- After applying: [Image](https://user-images.githubusercontent.com/43423211/167992539-9fea9484-5fc6-4a8f-bfdf-610665ab17f9.jpg)
