### PR TITLE
绝对路径换用相对路径，兼容子主题

### DIFF
--- a/layouts/imgbox.php
+++ b/layouts/imgbox.php
@@ -1,5 +1,5 @@
 <?php
-include(get_stylesheet_directory().'/layouts/all_opt.php');
+include('all_opt.php');
 $text_logo = iro_opt('text_logo');
 $print_social_zone = function() use ($all_opt,$social_display_icon):void{
     // 左箭头


### PR DESCRIPTION
我在使用子主题的时候，这里报了warining。
它用的绝对路径，读取的就是子主题里面的'all_opt.php'，如果不复制一个'all_opt.php'到子主题中，就会报warning。