### PR TITLE
fix:行内代码填充过大导致上下行填充重叠

### DIFF
--- a/style.css
+++ b/style.css
@@ -9755,7 +9755,7 @@ color: var(--theme-skin-matching,#F9D938);
   color: var(--theme-skin-matching,#F9D938);
   word-break: break-word;
   font-family: 'Noto Sans SC';
-  padding: 5px;
+  padding: 3px;
   text-shadow: none;
   border-radius: 5px
 }


### PR DESCRIPTION
默认配置下：
![](https://image.kanochan.net/2023/03/27/202303271440275.png)

修改后：
![](https://image.kanochan.net/2023/03/27/202303271441351.png)