### PR TITLE
修复：时光轴模板里多余的缩略图显示

### DIFF
--- a/user/page-timeline.php
+++ b/user/page-timeline.php
@@ -16,12 +16,7 @@ get_header();
             <article class="art">
                 <div class="art-main">
                     <div class="art-content">
-                        <?php if ( has_post_thumbnail() ) {
-							the_post_thumbnail();
-						}
-						the_content();
-						memory_archives_list();
-						?>
+                        <?php the_content(); memory_archives_list(); ?>
 					</div>
 				</div>
 			</article>


### PR DESCRIPTION
## 问题描述
新建页面时光轴模板，配置一张特色图片，时光轴页面显示多余的缩略图。

![](https://image.kanochan.net/2023/04/13/2023041316078304ad6337ef5ae6253.png)

## 修复后效果
![](https://image.kanochan.net/2023/04/13/202304131611826f85d6215fd6299ba.png)
移除了特色图片缩略图
