### PR TITLE
fix: 登录页面重载时有概率导致文本框无法输入

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -855,9 +855,9 @@ if ($custom_login_switch) {
                         document.body.style.backgroundImage = `url(${src})`
                         loading.classList.add("hide");
                         loading.classList.remove("show");
-                        loading.addEventListener("transitionend", () => {
+                        setTimeout(function() {
                             loading.remove()
-                        });
+                        }, 400);
                     },
                     img = document.createElement('img')
                 img.src = src


### PR DESCRIPTION
无法输入的原因是loading元素全屏遮挡了输入框
理论上资源加载完成后，应该要把loading移除，但是使用transitionend事件来触发移除操作，会概率性导致无法移除loading，具体原因暂不明。从测试上来看，页面加载速度越快，该问题出现的概率越大。有一个简单的触发步骤是：登录页面加载后，不输入任何信息，连续点击“登录”按钮。另外使用缓存刷新页面也有概率能够触发。

修正的话，是弃用transitionend事件，改为延迟400ms后直接移除loading元素。之所以是400ms，是因为以前transitionend事件的动画时间就是400ms。从体验上看，没有明显的视觉变化。 
#773 