### PR TITLE
Update fields.class.php

### DIFF
--- a/opt/classes/fields.class.php
+++ b/opt/classes/fields.class.php
@@ -9,7 +9,13 @@
  */
 if ( ! class_exists( 'CSF_Fields' ) ) {
   abstract class CSF_Fields extends CSF_Abstract {
-
+    
+    public $field;
+    public $value;
+    public $unique;
+    public $where;
+    public $parent;
+    
     public function __construct( $field = array(), $value = '', $unique = '', $where = '', $parent = '' ) {
       $this->field  = $field;
       $this->value  = $value;


### PR DESCRIPTION
解决warn：Deprecated: Creation of dynamic property CSF_Field_heading::$field is deprecated in /www/wwwroot/http://www.rwr.ink/wp-content/themes/Sakurairo-2.6.3.1/opt/classes/fields.class.php on line 14~18 
原因：较新版本PHP需先声明再创建类