### PR TITLE
fix：使主题进一步适配 PHP8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 
 ## 赞助商：
 
-<a href="https://www.upyun.com/"><img src="https://s.nmxc.ltd/sakurairo_vision/@2.6/options/upyun_logo.webp" alt="UPYUN" width="200"></a>
+<a href="https://www.upyun.com/"><img src="https://s.nmxc.ltd/sakurairo_vision/@2.6/readme/upyun2024.webp" alt="UPYUN" width="400"></a>
+<a href="https://www.houdeyun.cn/"><img src="https://s.nmxc.ltd/sakurairo_vision/@2.6/readme/houdeyun2024.webp" alt="HOUDEYUN" width="400"></a>
 
 ## 支持我们：
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 
 ## 赞助商：
 
-<a href="https://www.upyun.com/"><img src="https://s.nmxc.ltd/sakurairo_vision/@2.6/readme/upyun2024.webp" alt="UPYUN" width="400"></a>
+<a href="https://www.upyun.com/"><img src="https://s.nmxc.ltd/sakurairo_vision/@2.6/readme/upyun2024.webp" alt="UPYUN" width="400"></a>  
+
 <a href="https://www.houdeyun.cn/"><img src="https://s.nmxc.ltd/sakurairo_vision/@2.6/readme/houdeyun2024.webp" alt="HOUDEYUN" width="400"></a>
 
 ## 支持我们：

--- a/header.php
+++ b/header.php
@@ -40,19 +40,21 @@ $vision_resource_basepath = iro_opt('vision_resource_basepath');
 		if (is_singular()) {
 			$keywords = '';
 			$tags = get_the_tags();
-			$categories = get_the_category();
 			if ($tags) {
 				foreach ($tags as $tag) {
 					$keywords .= $tag->name . ',';
 				};
 			};
+			$description = mb_strimwidth(str_replace("\r\n", '', strip_tags($post->post_content)), 0, 240, '…');
+		} else if(is_category()) {
+		        $categories = get_the_category();
 			if ($categories) {
 				foreach ($categories as $category) {
 					$keywords .= $category->name . ',';
 				};
-			};
-			$description = mb_strimwidth(str_replace("\r\n", '', strip_tags($post->post_content)), 0, 240, '…');
-		} else {
+			}
+			$description = mb_strimwidth(str_replace("\r\n", '', strip_tags(category_description())), 0, 240, '…');
+		}  else {
 			$keywords = iro_opt('iro_meta_keywords');
 			$description = iro_opt('iro_meta_description');
 		};

--- a/opt/classes/fields.class.php
+++ b/opt/classes/fields.class.php
@@ -9,7 +9,13 @@
  */
 if ( ! class_exists( 'CSF_Fields' ) ) {
   abstract class CSF_Fields extends CSF_Abstract {
-
+    
+    protected $field;
+    protected $value;
+    protected $unique;
+    protected $where;
+    protected $parent;
+  
     public function __construct( $field = array(), $value = '', $unique = '', $where = '', $parent = '' ) {
       $this->field  = $field;
       $this->value  = $value;


### PR DESCRIPTION
php8.2弃用了动态属性，需要事先声明变量，否则提示弃用警告 Deprecated。

修复此报错
Deprecated: Creation of dynamic property CSF_Field_color::$value is deprecated in xxx/wp-content/themes/Sakurairo/opt/classes/fields.class.php on line xx

翻看之前推送的 Pull，似乎有推送一样的，但不知为何取消了。目前使用主题推荐的PHP版本，即 php8.3 依旧会报错。