### PR TITLE
fix(文章): 古腾堡编辑器创建的文章中，设定为居中对齐的图片的描述文本不居中

### DIFF
--- a/style.css
+++ b/style.css
@@ -1708,6 +1708,11 @@ h3#comments-list-title {
   margin-right: auto;
 }
 
+/*Fix [#836](https://github.com/mirai-mamori/Sakurairo/issues/836)*/
+.wp-block-image .aligncenter>figcaption{
+  text-align: center; 
+}
+
 #baguetteBox-overlay .full-image {
   cursor: -webkit-zoom-out;
   display: inline-block;


### PR DESCRIPTION
Fix #836