### PR TITLE
Fix: 优化 head 里面 description 与 keywords 值展示逻辑。

### DIFF
--- a/header.php
+++ b/header.php
@@ -35,29 +35,24 @@ $vision_resource_basepath = iro_opt('vision_resource_basepath');
     <link rel="stylesheet" href="<?= $vision_resource_basepath ?>fontawesome/css/all.min.css" type="text/css" media="all"/>
 	<?php
 	if (iro_opt('iro_meta') == true) {
-		$keywords = '';
-		$description = '';
+		$keywords = iro_opt('iro_meta_keywords');
+        $description = iro_opt('iro_meta_description');
 		if (is_singular()) {
-			$keywords = '';
 			$tags = get_the_tags();
-			if ($tags) {
-				foreach ($tags as $tag) {
-					$keywords .= $tag->name . ',';
-				};
-			};
-			$description = mb_strimwidth(str_replace("\r\n", '', strip_tags($post->post_content)), 0, 240, '…');
-		} else if(is_category()) {
+            if ($tags) {
+                $keywords = implode(',', array_column($tags, 'name'));
+            }     
+            if (!empty($post->post_content)) {
+                $description = trim(mb_strimwidth(preg_replace('/\s+/', ' ', strip_tags($post->post_content)), 0, 240, '…'));
+            }
+		}
+		if (is_category()) {
 		    $categories = get_the_category();
 			if ($categories) {
-				foreach ($categories as $category) {
-					$keywords .= $category->name . ',';
-				};
-			};
-			$description = mb_strimwidth(str_replace("\r\n", '', strip_tags(category_description())), 0, 240, '…');
-		} else {
-			$keywords = iro_opt('iro_meta_keywords');
-			$description = iro_opt('iro_meta_description');
-		};
+                $keywords = implode(',', array_column($categories, 'name'));
+            }
+            $description = trim(category_description()) ?: $description;
+		}
 	?>
 		<meta name="description" content="<?php echo $description; ?>" />
 		<meta name="keywords" content="<?php echo $keywords; ?>" />

--- a/header.php
+++ b/header.php
@@ -40,18 +40,20 @@ $vision_resource_basepath = iro_opt('vision_resource_basepath');
 		if (is_singular()) {
 			$keywords = '';
 			$tags = get_the_tags();
-			$categories = get_the_category();
 			if ($tags) {
 				foreach ($tags as $tag) {
 					$keywords .= $tag->name . ',';
 				};
 			};
+			$description = mb_strimwidth(str_replace("\r\n", '', strip_tags($post->post_content)), 0, 240, '…');
+		} else if(is_category()) {
+		    $categories = get_the_category();
 			if ($categories) {
 				foreach ($categories as $category) {
 					$keywords .= $category->name . ',';
 				};
-			};
-			$description = mb_strimwidth(str_replace("\r\n", '', strip_tags($post->post_content)), 0, 240, '…');
+			}
+			$description = mb_strimwidth(str_replace("\r\n", '', strip_tags(category_description())), 0, 240, '…');
 		} else {
 			$keywords = iro_opt('iro_meta_keywords');
 			$description = iro_opt('iro_meta_description');

--- a/header.php
+++ b/header.php
@@ -52,7 +52,7 @@ $vision_resource_basepath = iro_opt('vision_resource_basepath');
 				foreach ($categories as $category) {
 					$keywords .= $category->name . ',';
 				};
-			}
+			};
 			$description = mb_strimwidth(str_replace("\r\n", '', strip_tags(category_description())), 0, 240, '…');
 		} else {
 			$keywords = iro_opt('iro_meta_keywords');


### PR DESCRIPTION
## 问题
header.php 里面使用 is_singular() 判断当前页面，并以此来显示 description 与 keywords，但是 is_singular() 只判断当前页面是否为文章、页面、附件、自定义文章，并不包含判断当前页面是否为分类页面，而主题在 is_singular() 里面写了与分类页面 description 与 keywords展示，这是没有用处的。
## 解决方案
这里使用 is_category() 与 category_description() 对分类页面单独进行了处理。

---
## 问题
原有的 description 与 keywords 截取逻辑存在问题，例如在没有任何内容的页面中，description 或 keywords 就无法取得任何值，而直接展示为空，缺乏默认值。
## 解决方案
改主题设置中手动填写的 keywords 与 description 为默认值，当页面 keywords 或 description 为空时。

没有写为页面时，keywords 包含该页面标题而尽可能更好的符合该页面关键词，因为这更消耗资源。

*页面时，且页面文章没有内容时，description 是否设置默认值的问题，WordPress中无法单独为页面设置介绍，直接设置一个统一的默认值有可能影响搜索引擎等展示，是否留空让爬虫自己解决？同理还有分类页面。目前这里设置了一个默认值。*


---
## 问题
description 值输出时会出现带有换行的情况，keywords 循环拼接时会始终在末尾加一个英文逗号 , 
## 解决方案
采用新的函数方法