### PR TITLE
说说启用REST API支持

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -249,6 +249,7 @@ function shuoshuo_custom_init()
         'publicly_queryable' => true,
         'show_ui' => true,
         'show_in_menu' => true,
+        'show_in_rest' => true,
         'query_var' => true,
         'rewrite' => true,
         'capability_type' => 'post',


### PR DESCRIPTION
1、此举会使得说说帖子能够使用区块编辑器进行编辑
2、可以通过REST API处理说说（shuoshuo）类型的帖子，以便其它应用程序使用。
备注：对应的REST API路由为：/wp-json/wp/v2/shuoshuo 或者 /?rest_route=/shuoshuo