### PR TITLE
修复字体API地址设置被重置

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -618,8 +618,8 @@ function gfonts_updates($specified_version, $option_name) {
 
     if (version_compare($current_version, $specified_version, '>')) {
         $option_value = iro_opt($option_name);
-        if (empty($option_value) || $option_value !== 'cdn2.tianli0.top/fonts') {
-            $option_value = 'cdn2.tianli0.top/fonts';
+        if (empty($option_value)) {
+            $option_value = 'fonts.googleapis.com';
             iro_opt_update($option_name, $option_value);
         }
         


### PR DESCRIPTION
该函数存在两个判断，一是当该设置项为空时会赋予默认值，这是合理的；二是会判断当前值是否为默认值，若不是默认值会重置回默认值，该判断是多余的，且会导致问题。因此我删除了该判断，并且由于原默认字体API已失效，且谷歌官方API速度还不错，对默认字体API地址进行了修改