### PR TITLE
Update current_user_can('level_10') to current_user_can('administrator')

### DIFF
--- a/inc/theme_plus.php
+++ b/inc/theme_plus.php
@@ -12,7 +12,7 @@ show_admin_bar(false);
 
 function get_edit_html():string{
   global $user_ID;
-  if ($user_ID && current_user_can('level_10')) {
+  if ($user_ID && current_user_can('administrator')) {
     return '<span class="bull">·</span><a href="' . get_edit_post_link() . '">'.__("EDIT","sakurairo").'</a>';
 }
   return '';
@@ -152,7 +152,7 @@ if(iro_opt('not_robot')) add_action('pre_comment_on_post', 'siren_robot_comment'
 function scp_comment_post( $incoming_comment ) {
   // 为什么要拦自己呢？
   global $user_ID; 
-  if( $user_ID && current_user_can('level_10') ) {
+  if( $user_ID && current_user_can('administrator') ) {
     return( $incoming_comment );
   } elseif(!preg_match('/[一-龥]/u', $incoming_comment['comment_content'])){
     siren_ajax_comment_err('写点汉字吧。You should add some Chinese words.');
@@ -245,7 +245,7 @@ function gopage(url,descr) {
     window.setTimeout(() => { cb(5); }, 1000); //倒计时秒数在这捏
 }
   </script>  
-  <?php if(current_user_can('level_10')){ ?>
+  <?php if(current_user_can('administrator')){ ?>
   <div class="admin-login-check">
     <?php 
     echo login_ok(); 
@@ -276,7 +276,7 @@ function login_ok(){
   <p id="login-showtime"></p>
   <p class="ex-logout">
     <a href="<?php bloginfo('url'); ?>" title="<?php _e('Home','sakurairo')/*首页*/?>"><?php _e('Home','sakurairo')/*首页*/?></a>
-    <?php if(current_user_can('level_10')){  ?>
+    <?php if(current_user_can('administrator')){  ?>
     <a href="<?php bloginfo('url'); ?>/wp-admin/" title="<?php _e('Manage','sakurairo')/*后台*/?>" target="_top"><?php _e('Manage','sakurairo')/*后台*/?></a> 
     <?php } ?>
     <a href="<?php echo wp_logout_url(get_bloginfo('url')); ?>" title="<?php _e('Logout','sakurairo')/*登出*/?>" target="_top"><?php _e('Sign out? ','sakurairo')/*登出？*/?></a>
@@ -423,7 +423,7 @@ function header_user_menu()
           <div class="header-user-name-u"><?php echo $current_user->display_name; ?></div>
         </div>
         <div class="user-menu-option">
-          <?php if (current_user_can('level_10')) { ?>
+          <?php if (current_user_can('administrator')) { ?>
             <a href="<?php bloginfo('url'); ?>/wp-admin/" target="_blank"><?php _e('Dashboard', 'sakurairo')/*管理中心*/ ?></a>
             <a href="<?php bloginfo('url'); ?>/wp-admin/post-new.php" target="_blank"><?php _e('New post', 'sakurairo')/*撰写文章*/ ?></a>
           <?php } ?>
@@ -469,7 +469,7 @@ function m_user_menu()
         <span><?php echo $current_user->display_name; ?></span>
       </div>
       <div class="m-user-menu-option">
-        <?php if (current_user_can('level_10')) { ?>
+        <?php if (current_user_can('administrator')) { ?>
           <a href="<?php bloginfo('url'); ?>/wp-admin/" target="_blank"><?php _e('Dashboard', 'sakurairo')/*管理中心*/ ?></a>
           <a href="<?php bloginfo('url'); ?>/wp-admin/post-new.php" target="_blank"><?php _e('New post', 'sakurairo')/*撰写文章*/ ?></a>
         <?php } ?>


### PR DESCRIPTION
**概述:**
此更改将 current_user_can('level_10') 替换为 current_user_can('administrator')， level 数字的判断方式，官方已经建议不要再使用了，应尽量避免。

**详细描述:**
在 WordPress 中，`level_10` 是管理员用户（administrator）级别的别称。用户级别是在 [WordPress 1.5](https://codex.wordpress.org/Version_1.5) 中引入的，它们在 [WordPress 2.0](https://codex.wordpress.org/Version_2.0) 中被[角色和功能](https://codex.wordpress.org/Roles_and_Capabilities)所取代，并且在 [WordPress 3.0](https://codex.wordpress.org/Version_3.0) 中最终被弃用。

[User_Levels](https://codex.wordpress.org/User_Levels)

**其他注意事项:**
- 这个更改不会影响现有功能，仅提高了代码的健康度。



