### PR TITLE
修复启用pjax后footer处自定义增删内容脚本不再重新加载的bug

### DIFF
--- a/header.php
+++ b/header.php
@@ -90,6 +90,32 @@ header('X-Frame-Options: SAMEORIGIN');
 		</script>
 	<?php endif; ?>
 	<?= iro_opt("site_header_insert"); ?>
+
+	<?php if (iro_opt('poi_pjax')): ?>
+    <script>
+        const srcs = `
+            <?php echo iro_opt("pjax_keep_loading"); ?>
+        `;
+        document.addEventListener("pjax:complete", () => {
+            srcs.split(/[\n,]+/).forEach(path => {
+                path = path.trim();
+                if (!path) return; 
+                if (path.endsWith('.js')) {
+                    const script = document.createElement('script');
+                    script.src = path;
+                    script.async = true;
+                    document.body.appendChild(script);
+                } else if (path.endsWith('.css')) {
+                    const style = document.createElement('link');
+                    style.rel = 'stylesheet';
+                    style.href = path;
+                    document.head.appendChild(style);
+                }
+            });
+        });
+    </script>
+    <?php endif; ?>
+
 </head>
 
 <body <?php body_class(); ?>>

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -1270,9 +1270,9 @@ $prefix = 'iro_options';
       array(
         'id' => 'pjax_keep_loading',
         'type' => 'textarea',
-        'title' => __('启用pjax后footer处需要刷新的代码','sakurairo_csf'),
+        'title' => __('Resources that still need refreshing in the footer after enabling PJAX','sakurairo_csf'),
         'dependency' => array( 'poi_pjax', '==', 'true', '', 'true' ),
-        'desc' => __('启用pjax后，footer处的自定义内容在页面跳转后将不会被刷新，可以在此处填写每页都要重新加载的Javascript和样式的资源的路径，一行一个，在pjax完成内容加载后这些资源将会被重新加载','sakurairo_csf'),
+        'desc' => __('After enabling PJAX, custom content in the footer won’t be refreshed on page navigation. You can specify paths for JavaScript and stylesheet resources that need to be reloaded on each page in the footer here, one per line. These resources will be reloaded once PJAX completes content loading.','sakurairo_csf'),
       ),
 
       array(

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -1266,6 +1266,14 @@ $prefix = 'iro_options';
         'label' => __('Enabled by default, clicking to a new page will not require reloading','sakurairo_csf'),
         'default' => true
       ),
+      
+      array(
+        'id' => 'pjax_keep_loading',
+        'type' => 'textarea',
+        'title' => __('启用pjax后footer处需要刷新的代码','sakurairo_csf'),
+        'dependency' => array( 'poi_pjax', '==', 'true', '', 'true' ),
+        'desc' => __('启用pjax后，footer处的自定义内容在页面跳转后将不会被刷新，可以在此处填写每页都要重新加载的Javascript和样式的资源的路径，一行一个，在pjax完成内容加载后这些资源将会被重新加载','sakurairo_csf'),
+      ),
 
       array(
         'id' => 'nprogress_on',


### PR DESCRIPTION
添加了启用pjax后跳转后仍需反复重新加载的脚本的内容，

少部分玩家可能在footer处引入了动态添加备案信息的玩法或者自定义增删全局内容的玩法，

但是很遗憾，为了能启用不中断播放的页底播放器，在启用pjax后这些脚本会在跳转后失效，

在header处引用虽然能加载但是动态修改内容功能无效了，所以现在需要在pjax加载完成后刷新一遍。

这段代码可以让那些魔改玩法保活。