### PR TITLE
尝试修复了站内搜索的功能

### DIFF
--- a/search.php
+++ b/search.php
@@ -18,8 +18,6 @@ get_header(); ?>
 	$search_query = get_search_query();
 	$sticky_posts = get_option('sticky_posts');
 
-	//$is_author_page = is_author() && !is_home() && !is_category() && !is_tag();
-
 	//搜索页标题
 	if (!iro_opt('patternimg') || !get_random_bg_url()) : ?>
 	    <header class="page-header">
@@ -37,9 +35,6 @@ get_header(); ?>
 		'order' => 'DESC',
 	);
 	
-	//if ($is_author_page) {
-	//	$all_results_args['author'] = get_the_author_meta('ID');// 只获取当前作者的文章
-	//}
 	$all_results_query = new WP_Query($all_results_args);
 	
 	//结果

--- a/search.php
+++ b/search.php
@@ -24,6 +24,7 @@ get_header(); ?>
 			/* Start the Loop */
 			    the_post();
 			    get_template_part('tpl/content', 'thumbcard');
+			    the_posts_navigation();
 			endwhile;
 		else : ?>
 			<div class="search-box">

--- a/search.php
+++ b/search.php
@@ -19,12 +19,12 @@ get_header(); ?>
 					<h1 class="page-title"><?php printf(esc_html__('Search result: %s', 'sakurairo'), '<span>' . esc_html(get_search_query()) . '</span>'); ?></h1>
 				</header><!-- .page-header -->
 			<?php endif; ?>
-			    <?php
+			<?php
+			while ( have_posts() ) :
 			/* Start the Loop */
-			    while ( have_posts() ) :
-					the_post();
-				    get_template_part('tpl/content', 'thumbcard');
-			    endwhile;
+			    the_post();
+			    get_template_part('tpl/content', 'thumbcard');
+			endwhile;
 		else : ?>
 			<div class="search-box">
 				<!-- search start -->

--- a/search.php
+++ b/search.php
@@ -13,30 +13,89 @@ get_header(); ?>
 <section id="primary" class="content-area">
 	<main id="main" class="site-main" role="main">
 
-		<?php if (have_posts()) : ?>
-			<?php if (!iro_opt('patternimg') || !get_random_bg_url()) : ?>
-				<header class="page-header">
-					<h1 class="page-title"><?php printf(esc_html__('Search result: %s', 'sakurairo'), '<span>' . esc_html(get_search_query()) . '</span>'); ?></h1>
-				</header><!-- .page-header -->
-			<?php endif; ?>
-			<?php
-			while ( have_posts() ) :
-			/* Start the Loop */
-			    the_post();
-			    get_template_part('tpl/content', 'thumbcard');
-			    the_posts_navigation();
-			endwhile;
-		else : ?>
-			<div class="search-box">
-				<!-- search start -->
-				<form class="s-search">
-					<input class="text-input" type="search" name="s" placeholder="<?php esc_attr_e('Search...', 'sakurairo'); ?>" required>
-				</form>
-				<!-- search end -->
-			</div>
-			<?php get_template_part('tpl/content', 'none'); ?>
-		<?php endif; ?>
+	<?php
+	$paged = max(1, get_query_var('paged'));
+	$search_query = get_search_query();
+	$sticky_posts = get_option('sticky_posts');
 
+	//$is_author_page = is_author() && !is_home() && !is_category() && !is_tag();
+
+	//搜索页标题
+	if (!iro_opt('patternimg') || !get_random_bg_url()) : ?>
+	    <header class="page-header">
+		    <h1 class="page-title"><?php printf(esc_html__('Search result: %s', 'sakurairo'), '<span>' . esc_html($search_query) . '</span>'); ?></h1>
+		</header><!-- .page-header -->
+	<?php endif;
+
+	//结果排序方式
+    $all_results_args = array(
+		'post_type' => array('post', 'shuoshuo'),
+		'post_status' => 'publish',
+		's' => $search_query,
+		'posts_per_page' => -1,
+		'orderby' => 'relevance',
+		'order' => 'DESC',
+	);
+	
+	//if ($is_author_page) {
+	//	$all_results_args['author'] = get_the_author_meta('ID');// 只获取当前作者的文章
+	//}
+	$all_results_query = new WP_Query($all_results_args);
+	
+	//结果
+	$all_results = [];
+	$sticky_results = [];
+	$non_sticky_results = [];
+	
+	//分类置顶内容和非置顶内容
+	if ($all_results_query->have_posts()) :
+		while ($all_results_query->have_posts()) : $all_results_query->the_post();
+		if (in_array(get_the_ID(), $sticky_posts)) {
+			$sticky_results[] = $post;
+		} else {
+			$non_sticky_results[] = $post;
+		}
+	    endwhile;
+	endif;
+	wp_reset_postdata();
+
+	//合并结果,优先展示置顶文章
+	$all_results = array_merge($sticky_results, $non_sticky_results);
+
+	// 内容分页
+	$total_results = count($all_results);
+	$posts_per_page = 10;
+	$total_pages = ceil($total_results / $posts_per_page);
+	$current_page_results = array_slice($all_results, ($paged - 1) * $posts_per_page, $posts_per_page);
+
+	//输出当前页内容
+	if (!empty($current_page_results)) :
+		foreach ($current_page_results as $post) :
+			setup_postdata($post);
+			get_template_part('tpl/content', 'thumbcard');
+		endforeach;
+
+		//分页跳转
+		the_posts_pagination(array(
+			'total' => $total_pages,
+			'current' => $paged,
+		));
+	else :
+		//未找到搜索结果
+		?>
+		<div class="search-box">
+			<!-- search start -->
+		    <form class="s-search">
+			    <input class="text-input" type="search" name="s" placeholder="<?php esc_attr_e('Search...', 'sakurairo'); ?>" required>
+			</form>
+			<!-- search end -->
+		</div>
+        <?php get_template_part('tpl/content', 'none'); ?>
+	<?php
+	endif;
+	wp_reset_postdata();
+	?>
+		
 		<style>
 			.nav-previous,
 			.nav-next {

--- a/search.php
+++ b/search.php
@@ -19,10 +19,12 @@ get_header(); ?>
 					<h1 class="page-title"><?php printf(esc_html__('Search result: %s', 'sakurairo'), '<span>' . esc_html(get_search_query()) . '</span>'); ?></h1>
 				</header><!-- .page-header -->
 			<?php endif; ?>
-			<?php
+			    <?php
 			/* Start the Loop */
-			get_template_part('tpl/content', 'thumb');
-			the_posts_navigation();
+			    while ( have_posts() ) :
+					the_post();
+				    get_template_part('tpl/content', 'thumbcard');
+			    endwhile;
 		else : ?>
 			<div class="search-box">
 				<!-- search start -->


### PR DESCRIPTION
通过检索发现 content-thumb 模板涉及到主页和作者页的文章排序展示，不方便进行搜索方法编写，该改进仅针对搜索功能，
所以直接在搜索页模板进行修改。

通过先分类搜索符合关键词的内容，然后将分类的内容合并实现了置顶的相关结果优先展示

经过本地和线上测试有效，使用了官方的测试内容和十几篇随机文章和说说测试了部分关键词的搜索