### PR TITLE
改善多行个人说明文本显示

### DIFF
--- a/author.php
+++ b/author.php
@@ -11,7 +11,7 @@ get_header();
         <h3><?php the_author(); ?></h3>
         <div class="description">
             <?php 
-            $description = get_the_author_meta('description');
+            $description = htmlspecialchars(get_the_author_meta('description'), ENT_QUOTES, 'UTF-8');
             echo $description ? nl2br($description) : __("No personal profile set yet", "sakurairo"); 
             ?>
         </div>

--- a/style.css
+++ b/style.css
@@ -1577,7 +1577,7 @@ h1.page-title {
   max-width: 70%;
   width: fit-content;
   position: relative;
-  height: 110px;
+  min-height: 110px;
   left: 50%;
   transform: translateX(-50%);
   margin: 10% 0;
@@ -1636,8 +1636,8 @@ h1.page-title {
   font-size: 14px;
   font-weight: var(--global-font-weight);
   text-align: center;
-  overflow: hidden;
-  max-height: 20px;
+  overflow: auto;
+  max-height: 400px;
   height: fit-content;
   margin: 0 10px;
 }

--- a/tpl/section-article-function.php
+++ b/tpl/section-article-function.php
@@ -63,9 +63,12 @@ if (iro_opt("article_function")) {
                 if (empty($author_description)) {
                     $author_description = __('This author has not provided a description.', 'sakurairo');
                 }
+                // 对描述内容进行转义，防止XSS攻击
+    			$safe_description = htmlspecialchars($author_description, ENT_QUOTES, 'UTF-8');
             ?>
                 <div class="desc">
-                    <i class="fa-solid fa-feather" aria-hidden="true"></i><?= $author_description; ?>
+                    <i class="fa-solid fa-feather" aria-hidden="true"></i>
+                    <?php echo nl2br($safe_description);?>
                 </div>
             <?php } ?>
         </section>


### PR DESCRIPTION
1.修改css和php代码,以适应多行的个人说明文本正常显示
2.增加获取个人说明函数get_the_author_meta('description')后,进行文本过滤转义步骤,防止xss攻击
