### PR TITLE
fix(csf): 首次安装启用主题时首页白屏

### DIFF
--- a/opt/classes/admin-options.class.php
+++ b/opt/classes/admin-options.class.php
@@ -194,7 +194,7 @@ if ( ! class_exists( 'CSF_Options' ) ) {
         }
       }
 
-      if ( $this->args['save_defaults'] && empty( $tmp_options ) ) {
+      if ( $this->args['save_defaults'] && !empty(array_diff_key($this->options, $tmp_options))) {
         $this->save_options( $this->options );
       }
 


### PR DESCRIPTION
### 复现

全新安装的wordpress，安装并启用主题，在未进主题设置页面保存设置的情况下，打开网站首页。

![](https://github.com/user-attachments/assets/087792dc-68c0-4295-ac0d-895369c24f7e)

### 分析

在首次安装启动时，点击应用主题按钮后，主题会初始化，理论上会将有默认设置的选项写进数据库中，实际上也本应如此。

但是有几行代码，没有遵循主题的初始化步骤，直接把选项的值写进数据库中，导致了主题默认选项无法进行初始化。表象是打开首页白屏，如上图片所示。

https://github.com/mirai-mamori/Sakurairo/blob/93046f03196dea23a1d45dd2a85aca3749088518/opt/classes/admin-options.class.php#L197-L199

上面的代码是主题初始化过程中，写入选项默认值的逻辑：判断从数据库中获取到的设置项是否为空，如果为空，说明是一个船新安装的wordpress，然后写入默认值。

这很合理，但是有几个函数影响了这一个判断：

https://github.com/mirai-mamori/Sakurairo/blob/93046f03196dea23a1d45dd2a85aca3749088518/functions.php#L720-L797

functions.php里的函数会先于主题设置项初始化执行，导致的结果是，在主题设置项初始化之前，数据库中已经存在了数条设置项的默认值，进而当主题设置项初始化时，`$tmp_options`的值不为空，无法将默认值写入数据库中。

无论如何刷新首页，都是白屏，只能通过在后台设置中保存主题设置项解决这个问题。

### 解决

很简单，将判断条件更改为数据库设置项的key与选项定义里的key是否完全相符就可以了，如果不相符，说明未完全初始化。

