### PR TITLE
更换保活脚本的方式，发现直接插入页面不加载了

### DIFF
--- a/header.php
+++ b/header.php
@@ -93,6 +93,21 @@ header('X-Frame-Options: SAMEORIGIN');
 
 	<?php if (iro_opt('poi_pjax')): ?>
     <script>
+		function loadScript(url) {
+			fetch(url)
+				.then(response => {
+					if (!response.ok) {
+						throw new Error(`Failed to load script: ${url}`);
+					}
+					return response.text();
+				})
+				.then(scriptContent => {
+					new Function(scriptContent)();
+				})
+				.catch(error => {
+					console.error(error);
+				});
+		}
         const srcs = `
             <?php echo iro_opt("pjax_keep_loading"); ?>
         `;
@@ -101,10 +116,7 @@ header('X-Frame-Options: SAMEORIGIN');
                 path = path.trim();
                 if (!path) return; 
                 if (path.endsWith('.js')) {
-                    const script = document.createElement('script');
-                    script.src = path;
-                    script.async = true;
-                    document.body.appendChild(script);
+                    loadScript(path);
                 } else if (path.endsWith('.css')) {
                     const style = document.createElement('link');
                     style.rel = 'stylesheet';


### PR DESCRIPTION
改用使用javascript加载保活脚本，之前在页脚插入的方式太蠢了（之前到底是哪个天才想出来这么个馊主意？没错，是我）