### PR TITLE
限制目录的高度，确保内容不会超出窗口，修改了部分区域的鼠标样式

### DIFF
--- a/style.css
+++ b/style.css
@@ -6184,7 +6184,6 @@ a.toc-link {
 }
 
 .is-collapsible {
-  max-height: 1000px;
   overflow: hidden;
   transition: all .3s ease-in-out;
 }

--- a/style.css
+++ b/style.css
@@ -3471,7 +3471,7 @@ iframe {
 .toc-container {
   z-index: 98;
   width: 190px;
-  height: auto;
+  height: 100%;
   background-color: rgba(255, 255, 255, 0);
   right: calc((100% - 1250px)/ 2);
   top: 540px;
@@ -3483,12 +3483,12 @@ iframe {
 .toc {
   position: sticky;
   top: 12%;
-  max-height: 80vh; /* 限制最大高度为窗口的 80% */
+  max-height: 80vh;
+  overflow-y: scroll;
   box-shadow: 0 1px 30px -4px var(--friend-link-shadow);
   background: rgba(255, 255, 255, 0.5);
   padding: 10px 10px;
   width: fit-content;
-  overflow-y: auto;
   border-radius: 10px;
   border: 1.5px solid #FFFFFF;
 }
@@ -6170,12 +6170,16 @@ body.dark::-webkit-scrollbar-track {
 .toc-list {
   margin: 0;
   padding-left: 16px;
+  cursor: default;
 }
 
 a.toc-link {
   color: currentColor;
   height: 100%;
   font-size: 16px;
+}
+
+.toc-list-item > a > #text {
   cursor: pointer;
 }
 

--- a/style.css
+++ b/style.css
@@ -1634,6 +1634,43 @@ h3#comments-list-title {
   clear: both;
 }
 
+article h1,
+article h2,
+article h3,
+article h4,
+article h5,
+article h6,
+article strong {
+	font-weight: 600;
+}
+article h1,
+article h2,
+article h3,
+article h4,
+article h5,
+article h6 {
+	margin-top: 18px !important;
+	margin-bottom: 15px;
+}
+article h1 {
+	font-size: 30px;
+}
+article h2 {
+	font-size: 26px;
+}
+article h3 {
+	font-size: 22px;
+}
+article h4 {
+	font-size: 18px;
+}
+article h5 {
+	font-size: 15px;
+}
+article h6 {
+	font-size: 13px;
+}
+
 .comment-content:after {
   content: "";
   display: table;

--- a/style.css
+++ b/style.css
@@ -1634,43 +1634,6 @@ h3#comments-list-title {
   clear: both;
 }
 
-article h1,
-article h2,
-article h3,
-article h4,
-article h5,
-article h6,
-article strong {
-	font-weight: 600;
-}
-article h1,
-article h2,
-article h3,
-article h4,
-article h5,
-article h6 {
-	margin-top: 18px !important;
-	margin-bottom: 15px;
-}
-article h1 {
-	font-size: 30px;
-}
-article h2 {
-	font-size: 26px;
-}
-article h3 {
-	font-size: 22px;
-}
-article h4 {
-	font-size: 18px;
-}
-article h5 {
-	font-size: 15px;
-}
-article h6 {
-	font-size: 13px;
-}
-
 .comment-content:after {
   content: "";
   display: table;
@@ -4181,6 +4144,43 @@ td.hljs-ln-numbers {
   cursor: pointer;
   text-align: center;
   border-radius: 50%;
+}
+
+article h1,
+article h2,
+article h3,
+article h4,
+article h5,
+article h6,
+article strong {
+	font-weight: 600;
+}
+article h1,
+article h2,
+article h3,
+article h4,
+article h5,
+article h6 {
+	margin-top: 18px !important;
+	margin-bottom: 15px;
+}
+article h1 {
+	font-size: 30px;
+}
+article h2 {
+	font-size: 26px;
+}
+article h3 {
+	font-size: 22px;
+}
+article h4 {
+	font-size: 18px;
+}
+article h5 {
+	font-size: 15px;
+}
+article h6 {
+	font-size: 13px;
 }
 
 h1::before {

--- a/style.css
+++ b/style.css
@@ -3483,6 +3483,7 @@ iframe {
 .toc {
   position: sticky;
   top: 12%;
+  max-height: 80vh; /* 限制最大高度为窗口的 80% */
   box-shadow: 0 1px 30px -4px var(--friend-link-shadow);
   background: rgba(255, 255, 255, 0.5);
   padding: 10px 10px;
@@ -4144,43 +4145,6 @@ td.hljs-ln-numbers {
   cursor: pointer;
   text-align: center;
   border-radius: 50%;
-}
-
-article h1,
-article h2,
-article h3,
-article h4,
-article h5,
-article h6,
-article strong {
-	font-weight: 600;
-}
-article h1,
-article h2,
-article h3,
-article h4,
-article h5,
-article h6 {
-	margin-top: 18px !important;
-	margin-bottom: 15px;
-}
-article h1 {
-	font-size: 30px;
-}
-article h2 {
-	font-size: 26px;
-}
-article h3 {
-	font-size: 22px;
-}
-article h4 {
-	font-size: 18px;
-}
-article h5 {
-	font-size: 15px;
-}
-article h6 {
-	font-size: 13px;
 }
 
 h1::before {


### PR DESCRIPTION
限制目录的最大高度让滚动条能够正常工作
让撑出视野部分的目录标题能够以滚动的方式允许用户预览并选择跳转

修改了部分目录的鼠标样式，现在只有在文字上时，鼠标样式才会变成pointer，更符合用户直觉

前：
![image](https://github.com/user-attachments/assets/46ff9f29-b01c-43cb-8790-02df0763a6bd)
后：
![image](https://github.com/user-attachments/assets/86147a12-1503-44b3-92eb-c8e4511a1ee4)


