### PR TITLE
WordPress 脚注仅在本页内跳转

### DIFF
--- a/header.php
+++ b/header.php
@@ -117,6 +117,25 @@ header('X-Frame-Options: SAMEORIGIN');
     <?php endif;
     } ?>
 
+    <!--WordPress 脚注仅在本页内跳转-->
+    <script  type="text/javascript">
+    document.addEventListener('DOMContentLoaded', function () {
+        // Ensure all footnote links jump within the same page
+        document.querySelectorAll('a[href^="#"]').forEach(function (link) {
+            link.addEventListener('click', function (event) {
+                // Prevent default behavior if unnecessary
+                event.preventDefault();
+                // Find the target element
+                const targetId = this.getAttribute('href').substring(1);
+                const targetElement = document.getElementById(targetId);
+                if (targetElement) {
+                // Scroll to the target element
+                targetElement.scrollIntoView({ behavior: 'smooth' });
+                }
+            });
+        });
+    });
+	</script>
 </head>
 
 <body <?php body_class(); ?>>


### PR DESCRIPTION
使用 WordPress 编辑器的脚注功能时，点击脚注会打开新的标签页。对 `<a>` 标签包裹的以 `#` 开头的跳转链接将全部进行页面内的跳转