### PR TITLE
更改blockquote的样式，确保手机端引用正常显示

### DIFF
--- a/style.css
+++ b/style.css
@@ -259,29 +259,33 @@ pre {
 
 blockquote {
   margin: 0;
-  padding: 30px 60px;
+  /* padding: 30px 60px; */
   position: relative;
   quotes: "" "";
+}
+
+.comments blockquote{
+  padding: 30px 60px !important;
 }
 
 blockquote:before,
 blockquote:after {
   font-family: FontAwesome;
-  font-size: 3rem;
+  font-size: 1rem;
   color: var(--theme-skin, #505050);
   position: absolute;
 }
 
 blockquote:before {
   content: "\f10d" !important;
-  top: -25px;
-  left: 12px;
+  top: 20px;
+  left: 30px;
 }
 
 blockquote:after {
   content: '\f10e' !important;
-  bottom: -25px;
-  right: -5px;
+  bottom: 15px;
+  right: 20px;
 }
 
 .wrapper {

--- a/style.css
+++ b/style.css
@@ -264,6 +264,7 @@ blockquote {
   quotes: "" "";
 }
 
+.wp-block-quote,
 .comments blockquote{
   padding: 30px 60px !important;
 }


### PR DESCRIPTION
![6753ec6d73c3afb08c11a6848066dee6](https://github.com/user-attachments/assets/9c62c470-9c5f-43e0-83b3-8f0d3c4f8a89)
![ccc0526c8c21dfcdbecf56da2614e07b](https://github.com/user-attachments/assets/2e50b822-e569-4930-bb77-447c5fce9f34)
修复前

修复后：
![image](https://github.com/user-attachments/assets/9ba65498-480d-4cd9-b56e-090f20bf3912)
![image](https://github.com/user-attachments/assets/ad76c68e-85c6-45a7-95f0-866bd1ba5c8b)
![image](https://github.com/user-attachments/assets/dfde682c-8878-411e-9843-e5505f3731bd)

缩小了引号的大小，不再显得夸张，也不会在评论区被渲染时遮挡部分信息