### PR TITLE
改进了部分样式

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,7 +39,7 @@ li.comment,
 ul.search-no-reasults,
 ul.search-no-reasults li,
 ul.menu-list{
-  cursor: unset !important;
+  cursor: unset;
 }
 
 img {

--- a/style.css
+++ b/style.css
@@ -1673,6 +1673,10 @@ h3#comments-list-title {
   clear: both;
 }
 
+#al_expand_collapse{
+  cursor: pointer !important;
+}
+
 #archives-temp h2 {
   font-weight: 400;
   color: var(--theme-skin, #505050);

--- a/style.css
+++ b/style.css
@@ -4152,7 +4152,12 @@ td.hljs-ln-numbers {
   border-radius: 50%;
 }
 
-h1::before {
+h1::before,
+h2::before,
+h3::before,
+h4::before,
+h5::before,
+h6::before {
   display: block;
   content: " ";
   height: 80px;
@@ -4160,36 +4165,8 @@ h1::before {
   visibility: hidden;
 }
 
-h2::before {
-  display: block;
-  content: " ";
-  height: 80px;
-  margin-top: -80px;
-  visibility: hidden;
-}
-
-h3::before {
-  display: block;
-  content: " ";
-  height: 80px;
-  margin-top: -80px;
-  visibility: hidden;
-}
-
-h4::before {
-  display: block;
-  content: " ";
-  height: 80px;
-  margin-top: -80px;
-  visibility: hidden;
-}
-
-h5::before {
-  display: block;
-  content: " ";
-  height: 80px;
-  margin-top: -80px;
-  visibility: hidden;
+.main .body h1::before {
+  content: none;
 }
 
 .widget-area {

--- a/style.css
+++ b/style.css
@@ -30,11 +30,16 @@ i,i:hover{
 
 li,ul,ol {
   list-style: none;
+  cursor: pointer;
   padding-inline-start: unset;
 }
 
-.menu-list li{
-  cursor: pointer;
+ul.commentwrap,
+li.comment,
+ul.search-no-reasults,
+ul.search-no-reasults li,
+ul.menu-list{
+  cursor: unset !important;
 }
 
 img {

--- a/style.css
+++ b/style.css
@@ -30,7 +30,6 @@ i,i:hover{
 
 li,ul,ol {
   list-style: none;
-  cursor: pointer;
   padding-inline-start: unset;
 }
 
@@ -1975,8 +1974,6 @@ nav#comments-navi {
 }
 
 .comment h4 {
-  font-size: 24px;
-  font-weight: var(--global-font-weight, 400);
   margin: 0;
   letter-spacing: 0;
   text-transform: none;
@@ -7790,6 +7787,11 @@ body.dark .search_close:before {
 body.dark .openNav .icon,
 body.dark .openNav .icon:before {
   background-color: var(--theme-skin-dark);
+}
+
+body.dark .centerbg {
+  background-blend-mode: hard-light;
+  background-color: #333333;
 }
 
 body.dark input[type=color]:focus,

--- a/style.css
+++ b/style.css
@@ -33,6 +33,10 @@ li,ul,ol {
   padding-inline-start: unset;
 }
 
+.menu-list li{
+  cursor: pointer;
+}
+
 img {
   border: 0;
   height: auto;

--- a/style.css
+++ b/style.css
@@ -7789,11 +7789,6 @@ body.dark .openNav .icon:before {
   background-color: var(--theme-skin-dark);
 }
 
-body.dark .centerbg {
-  background-blend-mode: hard-light;
-  background-color: #333333;
-}
-
 body.dark input[type=color]:focus,
 body.dark input[type=date]:focus,
 body.dark input[type=datetime-local]:focus,

--- a/style.css
+++ b/style.css
@@ -3594,6 +3594,10 @@ iframe {
   color: var(--theme-skin, #505050);
 }
 
+.emotion-box img:hover {
+  transform: scale(1.2);
+}
+
 .no-select {
   -webkit-touch-callout: none;
   -webkit-user-select: none;


### PR DESCRIPTION
重置了部分元素的鼠标样式，包括评论区、相关搜索和小工具区域空白部分。
现在不会在与功能无关的区域也显示为pointer了，不会对用户造成误导。

清除了.comment h4的字体大小和字重，和其他标题一样统一使用用户代理样式，确保风格统一

合并了h1、h2、h3、h4、h5的前置伪元素样式，为h6添加相同样式，确保风格统一

排除了评论区的h1标题前置伪元素，当直接写标题时不再会开头莫名空出一大块，确保美观

设置archive页的按钮样式为poiner，更符合用户直觉，点击[展开/折叠]的功能和鼠标图标一致，而非上下拖拽按钮。

现在鼠标悬停在表情选区的图片上会略微放大，可能增强了体验。