### PR TITLE
修复了部分动画，修改了部分样式

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,6 +23,11 @@ Tags: 多彩、轻松上手、体验完善、高自定义度
   -webkit-transition: all 0.6s ease-in-out;
 }
 
+.error-img * {
+  transition: unset;
+  -webkit-transition: unset;
+}
+
 i,i:hover{
   transition: none;
   -webkit-transition: none;

--- a/style.css
+++ b/style.css
@@ -2266,12 +2266,12 @@ h1.main-title {
   height: 110px;
   text-align: center;
   border-radius: 10px;
-  z-index: -1;
+  z-index: 5;
   position: absolute;
   bottom: 0;
   width: 100%;
-  -webkit-transform: translateY(calc(70px + 1em));
-  transform: translateY(calc(70px + 1em));
+  -webkit-transform: translateY(0); 
+  transform: translateY(0);
   -webkit-transition: -webkit-transform .3s;
   transition: transform .3s, -webkit-transform .3s;
   font-weight: var(--global-font-weight);
@@ -5588,8 +5588,8 @@ li.feature-2 {
 
 .top-feature li:hover .feature-title .foverlay {
   z-index: 9;
-  -webkit-transform: translateY(0);
-  transform: translateY(0);
+  -webkit-transform: translateY(calc(70px + 1em)); 
+  transform: translateY(calc(70px + 1em));
 }
 
 .notice-content {

--- a/style.css
+++ b/style.css
@@ -2263,17 +2263,16 @@ h1.main-title {
 .feature-title .foverlay {
   color: #fff;
   font-size: 32px;
-  height: 110px;
+  margin-bottom: 55px;
+  width: 100%;
   text-align: center;
-  border-radius: 10px;
-  z-index: -1;
+  z-index: 9;
   position: absolute;
   bottom: 0;
-  width: 100%;
-  -webkit-transform: translateY(calc(70px + 1em));
-  transform: translateY(calc(70px + 1em));
-  -webkit-transition: -webkit-transform .3s;
-  transition: transform .3s, -webkit-transform .3s;
+  opacity: 0;
+  transform: scale(0.8);
+  -webkit-transition: opacity 0.4s ease-out, transform 0.4s ease-out;
+  transition: opacity 0.4s ease-out, transform 0.4s ease-out;
   font-weight: var(--global-font-weight);
 }
 
@@ -5587,9 +5586,9 @@ li.feature-2 {
 }
 
 .top-feature li:hover .feature-title .foverlay {
-  z-index: 9;
-  -webkit-transform: translateY(0);
-  transform: translateY(0);
+  opacity: 1;
+  transform: scale(1);
+  -webkit-transform: scale(1);
 }
 
 .notice-content {

--- a/style.css
+++ b/style.css
@@ -2266,12 +2266,12 @@ h1.main-title {
   height: 110px;
   text-align: center;
   border-radius: 10px;
-  z-index: 5;
+  z-index: -1;
   position: absolute;
   bottom: 0;
   width: 100%;
-  -webkit-transform: translateY(0); 
-  transform: translateY(0);
+  -webkit-transform: translateY(calc(70px + 1em));
+  transform: translateY(calc(70px + 1em));
   -webkit-transition: -webkit-transform .3s;
   transition: transform .3s, -webkit-transform .3s;
   font-weight: var(--global-font-weight);
@@ -5588,8 +5588,8 @@ li.feature-2 {
 
 .top-feature li:hover .feature-title .foverlay {
   z-index: 9;
-  -webkit-transform: translateY(calc(70px + 1em)); 
-  transform: translateY(calc(70px + 1em));
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
 }
 
 .notice-content {

--- a/style.css
+++ b/style.css
@@ -2263,6 +2263,11 @@ h1.main-title {
 .feature-title .foverlay {
   color: #fff;
   font-size: 32px;
+  text-shadow: 
+    1px -1px 0 rgba(0, 0, 0, 0.1), 
+    -1px -1px 0 rgba(0, 0, 0, 0.1), 
+    -1px 1px 0 rgba(0, 0, 0, 0.1), 
+    1px 1px 0 rgba(0, 0, 0, 0.1);
   margin-bottom: 55px;
   width: 100%;
   text-align: center;


### PR DESCRIPTION
重置404页面动图的动画属性

原来动画无法正常播放，仅在页面切换、滑动时缓慢、卡顿刷新

把它的动画样式去掉就好了

修改了展示区第二种形式的动画，不再突然出现而显得突兀，并添加了些微文字描边，以适应各种颜色的图片。