### PR TITLE
更方便的github仓库卡片短代码

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2385,8 +2385,54 @@ function register_shortcodes() {
     });
 
     add_shortcode('ghcard', function($attr, $content = '') {
-        $atts = shortcode_atts(array("path" => ""), $attr);
-        return '<div class="ghcard"><a href="https://github.com/' . esc_attr($atts['path']) . '"><img src="https://github-readme-stats.vercel.app/api' . esc_html($content) . '" alt="Github-Card"></a></div>';
+        //获取内容
+        $atts = shortcode_atts(array("path" => "mirai-mamori/Sakurairo"), $attr);
+
+        $path = trim($atts['path']);
+
+        if (strpos($path, 'https://github.com/') === 0) {
+            $path = str_replace('https://github.com/', '', $path);
+        }
+
+        if (!preg_match('/^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]+$/', $path)) {
+            return '<p>Invalid GitHub repository path: ' . esc_html($path) . '</p>';
+        }
+    
+        list($username, $repo) = explode('/', $path, 2);
+    
+        //构造卡片内容
+        $card_content = '';
+    
+        if (iro_opt('ghcard_proxy')) {
+            
+            $svg_url = 'https://github-readme-stats.vercel.app/api/pin/?username=' . esc_attr($username) . '&repo=' . esc_attr($repo);
+            $response = wp_remote_get($svg_url);
+    
+            if (!is_wp_error($response)) {
+                $svg_content = wp_remote_retrieve_body($response);
+                if (!empty($svg_content)) {
+                    $card_content = $svg_content;
+                } else {
+                    $card_content = '';
+                }
+            } else {
+                $card_content = '';
+            }
+        }
+    
+        //获取失败或未启用代理
+        if (empty($card_content)) {
+            $card_content = '<img decoding="async" src="https://github-readme-stats.vercel.app/api/pin/?username=' . esc_attr($username) . '&repo=' . esc_attr($repo) . '" alt="Github-Card">';
+        }
+    
+        //输出内容
+        $ghcard = '<div class="ghcard">';
+        $ghcard .= '<a href="https://github.com/' . esc_attr($path) . '">';
+        $ghcard .= $card_content;
+        $ghcard .= '</a>';
+        $ghcard .= '</div>';
+    
+        return $ghcard;
     });
 
     add_shortcode('showcard', function($attr, $content = '') {

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -3600,20 +3600,20 @@ $prefix = 'iro_options';
       ),
 
       array(
-        'id' => 'ghcard_proxy',
-        'type' => 'switcher',
-        'title' => __('GitHub repository card proxy','sakurairo_csf'),
-        'label' => __('Use your server proxy to get the github repository card image so that Chinese users who cannot access vercel.app can see it','sakurairo_csf'),
-        'default' => false
-      ),
-
-      array(
         'id' => 'custom_proxy_address_of_gravatar',
         'type' => 'text',
         'title' => __('Custom Proxy Address','sakurairo_csf'),
         'desc' => __('Enter your Gravatar proxy address without starting with "http(s)://" and ending with "/". Example: gravatar.com/avatar.','sakurairo_csf'),
         'dependency' => array( 'gravatar_proxy', '==', 'custom_proxy_address_of_gravatar', '', 'true' ),
         'default'     => 'gravatar.com/avatar'
+      ),
+
+      array(
+        'id' => 'ghcard_proxy',
+        'type' => 'switcher',
+        'title' => __('GitHub repository card proxy','sakurairo_csf'),
+        'desc' => __('Use your server proxy to get the github repository card image so that Chinese users who cannot access vercel.app can see it','sakurairo_csf'),
+        'default' => false
       ),
 
       array(

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -3600,6 +3600,14 @@ $prefix = 'iro_options';
       ),
 
       array(
+        'id' => 'ghcard_proxy',
+        'type' => 'switcher',
+        'title' => __('GitHub repository card proxy','sakurairo_csf'),
+        'label' => __('Use your server proxy to get the github repository card image so that Chinese users who cannot access vercel.app can see it','sakurairo_csf'),
+        'default' => false
+      ),
+
+      array(
         'id' => 'custom_proxy_address_of_gravatar',
         'type' => 'text',
         'title' => __('Custom Proxy Address','sakurairo_csf'),


### PR DESCRIPTION
填写`仓库链接`或者`用户名/仓库`都能识别  
[ghcard path="mirai-mamori/Sakurairo"][/ghcard]  
[ghcard path="https://github.com/mirai-mamori/Sakurairo"][/ghcard]

旧的也兼容  
[ghcard path="mirai-mamori/Sakurairo"]/pin/?username=mirai-mamori&repo=Sakurairo[/ghcard]

添加了为用户代理vercel.app获取卡片的选项