### PR TITLE
Fix bug: child-theme failure 修复子主题创建问题

### DIFF
--- a/inc/theme_plus.php
+++ b/inc/theme_plus.php
@@ -284,7 +284,7 @@ function the_headPattern(){
   $full_image_url = wp_get_attachment_image_src(get_post_thumbnail_id(get_the_ID()), 'full');
   $title_style = get_post_meta(get_the_ID(), 'title_style', true); // 获取自定义字段的值
   if(is_single()){
-    require_once get_stylesheet_directory() . '/tpl/entry-census.php';
+    require_once get_template_directory() . '/tpl/entry-census.php';
     $full_image_url = !empty($full_image_url) ? $full_image_url[0] : null;
     if (have_posts()) : while (have_posts()) : the_post();
     $center = 'single-center';
@@ -337,7 +337,7 @@ function the_video_headPattern(bool $isHls = false)
     }
     $thubm_image_url = !empty($thubm_image_urls) ? $thubm_image_urls[0] : null;
     if (is_single()) {
-      require_once get_stylesheet_directory() . '/tpl/entry-census.php';
+      require_once get_template_directory() . '/tpl/entry-census.php';
         while (have_posts()) {
             the_post();
             $center = 'single-center';

--- a/layouts/imgbox.php
+++ b/layouts/imgbox.php
@@ -1,5 +1,5 @@
 <?php
-include(get_stylesheet_directory().'/layouts/all_opt.php');
+include(get_template_directory().'/layouts/all_opt.php');
 $text_logo = iro_opt('text_logo');
 if (iro_opt('social_display_icon', '') === 'display_icon/remix_iconfont'): ?>
     <link rel="stylesheet" href="<?=iro_opt('vision_resource_basepath'); ?>display_icon/remix_iconfont/remix_social.css">

--- a/tpl/content-thumbcard.php
+++ b/tpl/content-thumbcard.php
@@ -12,29 +12,29 @@ if (!function_exists('render_article_meta')) {
         foreach ($article_meta_display_options as $key) {
             switch ($key) {
                 case "author":
-                    require_once get_stylesheet_directory() . '/tpl/meta-author.php';
+                    require_once get_template_directory() . '/tpl/meta-author.php';
                     render_author_meta();
                     break;
                 case "category":
-                    require_once get_stylesheet_directory() . '/tpl/meta-category.php';
+                    require_once get_template_directory() . '/tpl/meta-category.php';
                     echo get_meta_category_html();
                     break;
                 case "comment_count":
-                    require_once get_stylesheet_directory() . '/tpl/meta-comments.php';
+                    require_once get_template_directory() . '/tpl/meta-comments.php';
                     render_meta_comments();
                     break;
                 case "post_views":
                     render_meta_views();
                     break;
                 case "post_words_count":
-                    require_once get_stylesheet_directory() . '/tpl/meta-words-count.php';
+                    require_once get_template_directory() . '/tpl/meta-words-count.php';
                     $str = get_meta_words_count();
                     if ($str) {
                         ?><span><i class="fa-regular fa-pen-to-square"></i><?= esc_html($str) ?></span><?php
                     }
                     break;
                 case "reading_time":
-                    require_once get_stylesheet_directory() . '/tpl/meta-ert.php';
+                    require_once get_template_directory() . '/tpl/meta-ert.php';
                     $str = get_meta_estimate_reading_time();
                     if ($str) {
                         ?><span title="<?= esc_attr(__("Estimate Reading Time", "sakurairo")) ?>"><i class="fa-solid fa-hourglass"></i><?= esc_html($str) ?></span><?php

--- a/tpl/content-thumbcard.php
+++ b/tpl/content-thumbcard.php
@@ -13,29 +13,29 @@ if (!function_exists('render_article_meta')) {
             foreach ($article_meta_display_options as $key) {
                 switch ($key) {
                     case "author":
-                        require_once get_stylesheet_directory() . '/tpl/meta-author.php';
+                        require_once get_template_directory() . '/tpl/meta-author.php';
                         render_author_meta();
                         break;
                     case "category":
-                        require_once get_stylesheet_directory() . '/tpl/meta-category.php';
+                        require_once get_template_directory() . '/tpl/meta-category.php';
                         echo get_meta_category_html();
                         break;
                     case "comment_count":
-                        require_once get_stylesheet_directory() . '/tpl/meta-comments.php';
+                        require_once get_template_directory() . '/tpl/meta-comments.php';
                         render_meta_comments();
                         break;
                     case "post_views":
                         render_meta_views();
                         break;
                     case "post_words_count":
-                        require_once get_stylesheet_directory() . '/tpl/meta-words-count.php';
+                        require_once get_template_directory() . '/tpl/meta-words-count.php';
                         $str = get_meta_words_count();
                         if ($str) {
                             ?><span><i class="fa-regular fa-pen-to-square"></i><?= esc_html($str) ?></span><?php
                         }
                         break;
                     case "reading_time":
-                        require_once get_stylesheet_directory() . '/tpl/meta-ert.php';
+                        require_once get_template_directory() . '/tpl/meta-ert.php';
                         $str = get_meta_estimate_reading_time();
                         if ($str) {
                             ?><span title="<?= esc_attr(__("Estimate Reading Time", "sakurairo")) ?>"><i class="fa-solid fa-hourglass"></i><?= esc_html($str) ?></span><?php

--- a/tpl/entry-census.php
+++ b/tpl/entry-census.php
@@ -22,18 +22,18 @@ function get_entry_census_meta_html($has_splitter)
         $content = false;
         switch ($meta_key) {
             case "author":
-                require_once get_stylesheet_directory() . '/tpl/meta-author.php';
+                require_once get_template_directory() . '/tpl/meta-author.php';
                 ob_start();
                 render_author_meta();
                 $content = ob_get_contents();
                 ob_end_clean();
                 break;
             case "category":
-                require_once get_stylesheet_directory() . '/tpl/meta-category.php';
+                require_once get_template_directory() . '/tpl/meta-category.php';
                 $content = get_meta_category_html();
                 break;
             case "comment_count":
-                require_once get_stylesheet_directory() . '/tpl/meta-comments.php';
+                require_once get_template_directory() . '/tpl/meta-comments.php';
                 ob_start();
                 render_meta_comments();
                 $content = ob_get_contents();
@@ -48,7 +48,7 @@ function get_entry_census_meta_html($has_splitter)
                 }
                 break;
             case "post_words_count":
-                require_once get_stylesheet_directory() . '/tpl/meta-words-count.php';
+                require_once get_template_directory() . '/tpl/meta-words-count.php';
                 $content = get_meta_words_count();
                 if ($has_splitter) {
                     $content = __wrap_with_span($content);
@@ -57,7 +57,7 @@ function get_entry_census_meta_html($has_splitter)
                 }
                 break;
             case "reading_time":
-                require_once get_stylesheet_directory() . '/tpl/meta-ert.php';
+                require_once get_template_directory() . '/tpl/meta-ert.php';
                 $content = __("Estimate Reading Time", "sakurairo") . ": " . get_meta_estimate_reading_time();
                 if ($has_splitter) {
                     $content = __wrap_with_span($content);

--- a/tpl/single-entry-header.php
+++ b/tpl/single-entry-header.php
@@ -1,7 +1,7 @@
 <header class="entry-header">
     <h1 class="entry-title" style="<?php echo get_post_meta(get_the_ID(), 'title_style', true); ?>"><?php the_title(); ?></h1>
     <?php
-    require_once get_stylesheet_directory() . '/tpl/entry-census.php';
+    require_once get_template_directory() . '/tpl/entry-census.php';
     echo get_entry_census_html();
     ?>
     <hr>

--- a/update-checker/Puc/v5p1/Theme/Package.php
+++ b/update-checker/Puc/v5p1/Theme/Package.php
@@ -29,7 +29,7 @@ if ( !class_exists(Package::class, false) ):
 
 		public function getAbsoluteDirectoryPath() {
 			if ( method_exists($this->theme, 'get_stylesheet_directory') ) {
-				return $this->theme->get_template_directory(); //Available since WP 3.4.
+				return $this->theme->get_stylesheet_directory(); //Available since WP 3.4.
 			}
 			return get_theme_root($this->stylesheet) . '/' . $this->stylesheet;
 		}

--- a/update-checker/Puc/v5p1/Theme/Package.php
+++ b/update-checker/Puc/v5p1/Theme/Package.php
@@ -29,7 +29,7 @@ if ( !class_exists(Package::class, false) ):
 
 		public function getAbsoluteDirectoryPath() {
 			if ( method_exists($this->theme, 'get_stylesheet_directory') ) {
-				return $this->theme->get_stylesheet_directory(); //Available since WP 3.4.
+				return $this->theme->get_template_directory(); //Available since WP 3.4.
 			}
 			return get_theme_root($this->stylesheet) . '/' . $this->stylesheet;
 		}


### PR DESCRIPTION
原先所使用的`get_stylesheet_directory`接口总是获取当前主题的根目录，这会导致子主题创建错误。

## 问题描述
当用户从sakurairo创建子主题时，代码会试图从子主题寻找该文件，这会导致找不到文件从而报错。

例如文件`layouts\imgbox.php`中有如下代码
```php
<?php
include(get_stylesheet_directory().'/layouts/all_opt.php');
...
```
它总是会去找当前主题下的`'/layouts/all_opt.php'`文件。而用户一旦从sakurairo主题创建子主题，它就会尝试寻找子主题下的`'/layouts/all_opt.php'`文件——这个文件不存在于是就报错了。

而期望的行为应该是从父亲主题寻找该文件。

## 改进
所以，这些地方应该使用`get_template_directory`接口。
这两个接口的区别如下：
- `get_stylesheet_directory`，总是返回当前主题的绝对路径，无论是否为子主题。
- `get_template_directory`，如果当前启用的主题是一个子主题，该函数返回父主题的主题目录的服务器绝对路径；否则，返回当前主题的绝对路径。

于是换用该接口后，这些地方总是返回父主题（也即sakurairo主题）的绝对路径。
修复该bug后，可以正常从sakurairo主题创建子主题。