### PR TITLE
替换主题验证码为计算题，加入难度配置

### DIFF
--- a/inc/classes/Captcha.php
+++ b/inc/classes/Captcha.php
@@ -6,16 +6,16 @@ namespace Sakura\API;
 
 class Captcha
 {
-    private $captchText;
-    private $captchResult;
+    private $captchaText;
+    private $captchaResult;
 
     /**
      * CAPTCHA constructor.
      */
     public function __construct()
     {
-        $this->captchText = '';
-        $this->captchResult = '';
+        $this->captchaText = '';
+        $this->captchaResult = '';
     }
 
     /**
@@ -25,21 +25,18 @@ class Captcha
      */
     private function create_captcha(): void
     {
-        $n1 = rand(10, 99);
-        $n2 = rand(10, 99);
-        if (rand(0, 1)) {
+        $n1 = mt_rand(10, 99);
+        $n2 = mt_rand(10, 99);
+        if (mt_rand(0, 1)) {
             //加法
-            $this->captchText = "{$n1}+{$n2}=?";
-            $this->captchResult = $n1 + $n2;
+            $this->captchaText = "{$n1}+{$n2}=?";
+            $this->captchaResult = $n1 + $n2;
         } else {
             //减法(避免负数)
-            if ($n1 > $n2) {
-                $this->captchText = "{$n1}-{$n2}=?";
-                $this->captchResult = $n1 - $n2;
-            } else {
-                $this->captchText = "{$n2}-{$n1}=?";
-                $this->captchResult = $n2 - $n1;
-            }
+            $min = min($n1, $n2);
+            $max = max($n1, $n2);
+            $this->captchaText = "{$max}-{$min}=?";
+            $this->captchaResult = $max - $min;
         }
     }
 
@@ -51,7 +48,7 @@ class Captcha
     private function crypt_captcha(): string
     {
         //return md5($this->captchCode);
-        return password_hash($this->captchResult, PASSWORD_DEFAULT);
+        return password_hash($this->captchaResult, PASSWORD_DEFAULT);
         // return wp_hash_password($this->captchCode);
     }
 
@@ -91,41 +88,41 @@ class Captcha
         //创建画布
         $image = imagecreatetruecolor(210, 60);
         //填充背景色
-        $color = imagecolorallocate($image, rand(200, 255), rand(200, 255), rand(200, 255));
+        $color = imagecolorallocate($image, mt_rand(200, 255), mt_rand(200, 255), mt_rand(200, 255));
         imagefill($image, 0, 0, $color);
 
         //绘制文字
-        $chars = str_split($this->captchText);
-        for ($i = 0; $i < 7; $i++) {
+        $chars = str_split($this->captchaText);
+        for ($i = 0; $i < count($chars); $i++) {
             $char = $chars[$i];
-            $color = imagecolorallocate($image, rand(0, 150), rand(0, 150), rand(0, 150));
+            $color = imagecolorallocate($image, mt_rand(0, 150), mt_rand(0, 150), mt_rand(0, 150));
             $x = 30 * $i + 10;
-            $y = 30 + rand(-5, 5);
+            $y = 30 + mt_rand(-5, 5);
             //加减符号不倾斜 并加大字体
             $size = ($i === 2) ? 30 : 20;
-            $angle = ($i === 2) ? 0 : rand(-25, 25);
+            $angle = ($i === 2) ? 0 : mt_rand(-25, 25);
             imagettftext($image, $size, $angle, $x, $y, $color, $font, $char);
         }
         
         //添加噪点
         for ($i = 0; $i < $conf['noise']; $i++) {
-            $color = imagecolorallocate($image, rand(0, 255), rand(0, 255), rand(0, 255));
-            imagesetpixel($image, rand(0, 210), rand(0, 60), $color);
+            $color = imagecolorallocate($image, mt_rand(0, 255), mt_rand(0, 255), mt_rand(0, 255));
+            imagesetpixel($image, mt_rand(0, 210), mt_rand(0, 60), $color);
         }
         
         // 添加贝塞尔曲线
         for ($i = 0; $i < $conf['curves']; $i++) {
-            $color = imagecolorallocate($image, rand(50,150), rand(50, 150), rand(50, 150));
+            $color = imagecolorallocate($image, mt_rand(50,150), mt_rand(50, 150), mt_rand(50, 150));
             
             // 贝塞尔曲线控制点
-            $x1 = rand(0, 210);
-            $x2 = rand(0, 210);
-            $cx1 = rand(0, 210);
-            $cx2 = rand(0, 210);
-            $y1 = rand(0, 60);
-            $y2 = rand(0, 60);
-            $cy1 = rand(0, 60);
-            $cy2 = rand(0, 60);
+            $x1 = mt_rand(0, 210);
+            $x2 = mt_rand(0, 210);
+            $cx1 = mt_rand(0, 210);
+            $cx2 = mt_rand(0, 210);
+            $y1 = mt_rand(0, 60);
+            $y2 = mt_rand(0, 60);
+            $cy1 = mt_rand(0, 60);
+            $cy2 = mt_rand(0, 60);
             
             // 绘制贝塞尔曲线
             for ($t = 0; $t <= 1; $t += 0.01) {
@@ -138,7 +135,7 @@ class Captcha
         imagefilter($image, IMG_FILTER_GAUSSIAN_BLUR);
         
         $timestamp = time();
-        $this->captchResult .= $timestamp;
+        $this->captchaResult .= $timestamp;
         //打开缓存区
         ob_start();
         //降低图片质量

--- a/inc/classes/Captcha.php
+++ b/inc/classes/Captcha.php
@@ -6,14 +6,16 @@ namespace Sakura\API;
 
 class Captcha
 {
-    private $captchCode;
+    private $captchText;
+    private $captchResult;
 
     /**
      * CAPTCHA constructor.
      */
     public function __construct()
     {
-        $this->captchCode = '';
+        $this->captchText = '';
+        $this->captchResult = '';
     }
 
     /**
@@ -23,11 +25,22 @@ class Captcha
      */
     private function create_captcha(): void
     {
-        $dict = str_split('abcdefhjkmnpqrstuvwxy12345678');
-        $randKeys = array_rand($dict, 5);
-        $this->captchCode = implode('', array_map(function ($value) use ($dict) {
-            return $dict[$value];
-        }, $randKeys));
+        $n1 = rand(10, 99);
+        $n2 = rand(10, 99);
+        if (rand(0, 1)) {
+            //加法
+            $this->captchText = "{$n1}+{$n2}=?";
+            $this->captchResult = $n1 + $n2;
+        } else {
+            //减法(避免负数)
+            if ($n1 > $n2) {
+                $this->captchText = "{$n1}-{$n2}=?";
+                $this->captchResult = $n1 - $n2;
+            } else {
+                $this->captchText = "{$n2}-{$n1}=?";
+                $this->captchResult = $n2 - $n1;
+            }
+        }
     }
 
     /**
@@ -38,7 +51,7 @@ class Captcha
     private function crypt_captcha(): string
     {
         //return md5($this->captchCode);
-        return password_hash($this->captchCode, PASSWORD_DEFAULT);
+        return password_hash($this->captchResult, PASSWORD_DEFAULT);
         // return wp_hash_password($this->captchCode);
     }
 
@@ -63,44 +76,79 @@ class Captcha
      */
     public function create_captcha_img(): array
     {
-        //创建画布
-        $img = imagecreatetruecolor(120, 40);
-        $file = STYLESHEETPATH . '/inc/KumoFont.ttf';
-        //填充背景色
-        $backcolor = imagecolorallocate($img, mt_rand(200, 255), mt_rand(200, 255), mt_rand(0, 255));
-        imagefill($img, 0, 0, $backcolor);
-
+        //动态计算验证码难度
+        $level = iro_opt('iro_captcha_level') / 100;
+        $conf = array(
+          'noise' => (int)(500 + 1500 * $level),
+          'curves' => (int)(5 + 15 * $level),
+          'quality' => (int)(80 - 70 * $level)
+        );
+        
         //创建验证码
         $this->create_captcha();
+        $font = STYLESHEETPATH . '/inc/KumoFont.ttf';
+        
+        //创建画布
+        $image = imagecreatetruecolor(210, 60);
+        //填充背景色
+        $color = imagecolorallocate($image, rand(200, 255), rand(200, 255), rand(200, 255));
+        imagefill($image, 0, 0, $color);
+
         //绘制文字
-        for ($i = 0; $i < 5; $i++) {
-            // $span = 20;
-            $stringcolor = imagecolorallocate($img, mt_rand(0, 255), mt_rand(0, 100), mt_rand(0, 80));
-            imagefttext($img, 25, 2, $i * 20, 30, $stringcolor, $file, $this->captchCode[$i]);
+        $chars = str_split($this->captchText);
+        for ($i = 0; $i < 7; $i++) {
+            $char = $chars[$i];
+            $color = imagecolorallocate($image, rand(0, 150), rand(0, 150), rand(0, 150));
+            $x = 30 * $i + 10;
+            $y = 30 + rand(-5, 5);
+            //加减符号不倾斜 并加大字体
+            $size = ($i === 2) ? 30 : 20;
+            $angle = ($i === 2) ? 0 : rand(-25, 25);
+            imagettftext($image, $size, $angle, $x, $y, $color, $font, $char);
         }
-
-        //添加干扰线
-        for ($i = 0; $i < 8; $i++) {
-            $linecolor = imagecolorallocate($img, mt_rand(0, 150), mt_rand(0, 250), mt_rand(0, 255));
-            imageline($img, mt_rand(0, 179), mt_rand(0, 39), mt_rand(0, 179), mt_rand(0, 39), $linecolor);
+        
+        //添加噪点
+        for ($i = 0; $i < $conf['noise']; $i++) {
+            $color = imagecolorallocate($image, rand(0, 255), rand(0, 255), rand(0, 255));
+            imagesetpixel($image, rand(0, 210), rand(0, 60), $color);
         }
-
-        //添加干扰点
-        for ($i = 0; $i < 144; $i++) {
-            $pixelcolor = imagecolorallocate($img, mt_rand(100, 150), mt_rand(0, 120), mt_rand(0, 255));
-            imagesetpixel($img, mt_rand(0, 179), mt_rand(0, 39), $pixelcolor);
+        
+        // 添加贝塞尔曲线
+        for ($i = 0; $i < $conf['curves']; $i++) {
+            $color = imagecolorallocate($image, rand(50,150), rand(50, 150), rand(50, 150));
+            
+            // 贝塞尔曲线控制点
+            $x1 = rand(0, 210);
+            $x2 = rand(0, 210);
+            $cx1 = rand(0, 210);
+            $cx2 = rand(0, 210);
+            $y1 = rand(0, 60);
+            $y2 = rand(0, 60);
+            $cy1 = rand(0, 60);
+            $cy2 = rand(0, 60);
+            
+            // 绘制贝塞尔曲线
+            for ($t = 0; $t <= 1; $t += 0.01) {
+                $xt = (int)((1 - $t) * (1 - $t) * (1 - $t) * $x1 + 3 * (1 - $t) * (1 - $t) * $t * $cx1 + 3 * (1 - $t) * $t * $t * $cx2 + $t * $t * $t * $x2);
+                $yt = (int)((1 - $t) * (1 - $t) * (1 - $t) * $y1 + 3 * (1 - $t) * (1 - $t) * $t * $cy1 + 3 * (1 - $t) * $t * $t * $cy2 + $t * $t * $t * $y2);
+                imagesetpixel($image, $xt, $yt, $color);
+            }
         }
+        //启用高斯模糊，进一步降低清晰度
+        imagefilter($image, IMG_FILTER_GAUSSIAN_BLUR);
+        
         $timestamp = time();
-        $this->captchCode .= $timestamp;
+        $this->captchResult .= $timestamp;
         //打开缓存区
         ob_start();
-        imagepng($img);
+        //降低图片质量
+        imagejpeg($image, null, $conf['quality']);
         //输出图片
         $captchaimg =  ob_get_contents();
         //销毁缓存区
         ob_end_clean();
         //销毁图片(释放资源)
-        imagedestroy($img);
+        imagedestroy($image);
         // 以json格式输出
         $captchaimg = 'data:image/png;base64,' . base64_encode($captchaimg);
         return [
@@ -126,7 +174,8 @@ class Captcha
         if (!isset($timestamp) || !isset($id) || !preg_match('/^[\w$.\/]+$/', $id) || !ctype_digit((string)$timestamp)) {
             $code = 3;
             $msg = __('Bad Request.',"sakurairo");//非法请求
-        } elseif (empty($captcha) || strlen($captcha) !== 5) {
+        } elseif (!preg_match('/^(?:(?!199)(?:[1-9]\d?|1\d{2}|0))$/', $captcha)) {
+            //匹配非0 ~ 198
             $code = 3;
             $msg = __("Look like you forgot to enter the captcha.","sakurairo");//请输入正确的验证码!
         } elseif ($timestamp < $timeThreshold) {

--- a/inc/classes/Captcha.php
+++ b/inc/classes/Captcha.php
@@ -76,9 +76,9 @@ class Captcha
         //动态计算验证码难度
         $level = iro_opt('iro_captcha_level') / 100;
         $conf = array(
-          'noise' => (int)(500 + 1500 * $level),
-          'curves' => (int)(5 + 15 * $level),
-          'quality' => (int)(80 - 70 * $level)
+          'noise' => (int)(700 + 500 * $level),
+          'curves' => (int)(8 + 6 * $level),
+          'quality' => (int)(100 - 40 * $level)
         );
         
         //创建验证码

--- a/inc/swicher.php
+++ b/inc/swicher.php
@@ -81,7 +81,7 @@ function font_end_js_control()
         'comment_upload_img' => iro_opt('img_upload_api') == 'off' ? false : true,
         'cache_cover' => check(iro_opt('cache_cover')),
         'site_bg_as_cover' => check(iro_opt('site_bg_as_cover')),
-        'yiyan_api' => empty(iro_opt('yiyan')) ? ["https://v1.hitokoto.cn/", "https://api.nmxc.ltd/yiyan/"] : json_decode(iro_opt('yiyan_api')),
+        'yiyan_api' => empty(iro_opt('yiyan_api')) ? ["https://v1.hitokoto.cn/", "https://api.nmxc.ltd/yiyan/"] : json_decode(iro_opt('yiyan_api')),
         'skin_bg0' => '',
         'skin_bg1' => $vision_resource_basepath . 'background/foreground/bg1.png',
         'skin_bg2' => $vision_resource_basepath . 'background/foreground/bg2.png',

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -1267,7 +1267,19 @@ $prefix = 'iro_options';
         ),
         'default' => 'off',
       ),
-
+      
+      array(
+        'id' => 'iro_captcha_level',
+        'type' => 'slider',
+        'title' => __('Captcha Level', 'sakurairo_csf'),
+        'desc' => __('The difficulty level of the Theme Captcha', 'sakurairo_csf'),
+        'dependency' => array( 'captcha_select', '==', 'iro_captcha', '', 'true' ),
+        'step' => '1',
+        'min' => '0',
+        'max' => '100',
+        'default' => '70'
+      ),
+      
       array(
         'id' => 'vaptcha_vid',
         'type' => 'text',

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -1277,7 +1277,7 @@ $prefix = 'iro_options';
         'step' => '1',
         'min' => '0',
         'max' => '100',
-        'default' => '70'
+        'default' => '60'
       ),
       
       array(


### PR DESCRIPTION
将原来的图形验证码替换成计算题，
验证码的复杂和清晰度会随难度而动态变化，
可在主题配置里自行调整，以下为Demo：
- 难度为0
![af97406d762f421c9b1c3707d9266498](https://github.com/user-attachments/assets/72885316-4f18-4c6f-83af-a8b911b7d0fd)
- 难度70 (默认)
![a80d40c8a8364b92a7d204fc70389664](https://github.com/user-attachments/assets/8ea87b45-2748-4c39-ae84-9a04cc4d5c2e)
- 难度100
![e81b636cf8584b28bbd27d171f7d0c19](https://github.com/user-attachments/assets/380687ca-23c7-45de-b851-686b4d8fc87b)

- 同时使用0~100的滑块作为难度配置
![IMG_20250105_194537](https://github.com/user-attachments/assets/19e2d96f-edf8-4b20-b697-816c405200c0)
