### PR TITLE
修复mal模版一处编码问题导致的报错

### DIFF
--- a/inc/classes/MyAnimeList.php
+++ b/inc/classes/MyAnimeList.php
@@ -25,7 +25,7 @@ class MyAnimeList
 
 		if ($bangumi_cache) {
 
-            $cached_content = iro_opt('bangumi_cache_content');
+            $cached_content = json_decode(iro_opt('bangumi_cache_content'),true);
 
 			if ($cached_content) {
 				return $cached_content;


### PR DESCRIPTION
保存响应内容时编码了，但是使用时没有解码，导致相关功能故障