### PR TITLE
[PHP 8.4] 修复隐式可空参数废弃警告 (#1047)

### DIFF
--- a/update-checker/Puc/v5p1/StateStore.php
+++ b/update-checker/Puc/v5p1/StateStore.php
@@ -77,7 +77,7 @@ if ( !class_exists(StateStore::class, false) ):
 		 * @param Update|null $update
 		 * @return $this
 		 */
-		public function setUpdate(Update $update = null) {
+		public function setUpdate(?Update $update) {
 			$this->lazyLoad();
 			$this->update = $update;
 			return $this;

--- a/update-checker/Puc/v5p1/UpdateChecker.php
+++ b/update-checker/Puc/v5p1/UpdateChecker.php
@@ -459,7 +459,7 @@ if ( !class_exists(UpdateChecker::class, false) ):
 		 *
 		 * @param Metadata|null $update
 		 */
-		protected function fixSupportedWordpressVersion(Metadata $update = null) {
+		protected function fixSupportedWordpressVersion(?Metadata $update) {
 			if ( !isset($update->tested) || !preg_match('/^\d++\.\d++$/', $update->tested) ) {
 				return;
 			}

--- a/update-checker/vendor/ParsedownModern.php
+++ b/update-checker/vendor/ParsedownModern.php
@@ -648,7 +648,7 @@ class Parsedown
     #
     # Setext
 
-    protected function blockSetextHeader($Line, array $Block = null)
+    protected function blockSetextHeader($Line, ?array $Block)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {
@@ -786,7 +786,7 @@ class Parsedown
     #
     # Table
 
-    protected function blockTable($Line, array $Block = null)
+    protected function blockTable($Line, ?array $Block)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {


### PR DESCRIPTION
## 问题描述
PHP 8.4 中废弃了函数参数的隐式可空声明方式（`param = NULL`），需要改为显式声明（`?param`）。

## 修改内容
将函数参数的隐式可空声明更新为显式声明：

修改前：
```php
function example(string $param = NULL)