### PR TITLE
更新菜单交互逻辑，防止出现量子叠加态

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -956,24 +956,26 @@ const BrowserDetect = {
     }
 };
 
+//防止子菜单量子叠加
 document.addEventListener("DOMContentLoaded", () => {
-    const menuItems = document.querySelectorAll('.menu > li');
+    const menuItems = document.querySelectorAll('nav .menu > li');
     let activeSubMenu = null;
-    
+
     menuItems.forEach(item => {
-      const subMenu = item.querySelector('.sub-menu');
+        const subMenu = item.querySelector('.sub-menu');
 
-      //鼠标移入时激活子菜单
-      item.addEventListener('mouseenter', () => {
-        if (activeSubMenu && activeSubMenu !== subMenu) {
-          //有且仅有一个激活
-          activeSubMenu.classList.remove('active');
-        }
+        if (!subMenu) return;
 
-        //激活当前子菜单
-        subMenu.classList.add('active');
-        activeSubMenu = subMenu; //更新当前激活子菜单
-      });
+        //鼠标移入时激活子菜单
+        item.addEventListener('mouseenter', () => {
+            if (activeSubMenu && activeSubMenu !== subMenu) {
+                //有且仅有一个激活
+                activeSubMenu.classList.remove('active');
+            }
 
+            //更新并激活当前子菜单
+            subMenu.classList.add('active');
+            activeSubMenu = subMenu;
+        });
     });
-  });
+});

--- a/js/nav.js
+++ b/js/nav.js
@@ -955,3 +955,25 @@ const BrowserDetect = {
         return 'WebkitAppearance' in document.documentElement.style;
     }
 };
+
+document.addEventListener("DOMContentLoaded", () => {
+    const menuItems = document.querySelectorAll('.menu > li');
+    let activeSubMenu = null;
+    
+    menuItems.forEach(item => {
+      const subMenu = item.querySelector('.sub-menu');
+
+      //鼠标移入时激活子菜单
+      item.addEventListener('mouseenter', () => {
+        if (activeSubMenu && activeSubMenu !== subMenu) {
+          //有且仅有一个激活
+          activeSubMenu.classList.remove('active');
+        }
+
+        //激活当前子菜单
+        subMenu.classList.add('active');
+        activeSubMenu = subMenu; //更新当前激活子菜单
+      });
+
+    });
+  });

--- a/style.css
+++ b/style.css
@@ -746,6 +746,11 @@ nav .menu > li .sub-menu {
   flex-direction: column;
   padding: 5px 0;
   border: 1px solid #f7f7f7;
+  pointer-events: none;
+}
+
+.sub-menu.active {
+  pointer-events: auto !important;
 }
 
 nav .menu > li .sub-menu:hover {


### PR DESCRIPTION
现在子菜单默认禁止交互

通过主菜单选项激活后才可以交互

有且仅有一个子菜单可以交互

防止部分用户鼠标移动太快出现两个子菜单冲突的量子叠加态

更新前：

https://github.com/user-attachments/assets/24b29f8b-e78b-41af-ba97-34a900ced659



更新后：

https://github.com/user-attachments/assets/25ff4da7-7cf4-4a36-ad41-915f4cebd854

