### PR TITLE
Fix bug: child-theme failure caused by deprecated API 修复弃用API引起的子主题创建问题

### DIFF
--- a/inc/classes/Captcha.php
+++ b/inc/classes/Captcha.php
@@ -83,7 +83,8 @@ class Captcha
         
         //创建验证码
         $this->create_captcha();
-        $font = STYLESHEETPATH . '/inc/KumoFont.ttf';
+        // 自 wordpress 6.4.0 起，弃用了STYLESHEETPATH定义. 为确保子主题能正常使用，应当使用get_template_directory()接口
+        $font = get_template_directory() . '/inc/KumoFont.ttf';
         
         //创建画布
         $image = imagecreatetruecolor(210, 60);

--- a/inc/classes/Images.php
+++ b/inc/classes/Images.php
@@ -190,8 +190,7 @@ class Images
         if (iro_opt('random_graphs_options') == 'local') {
             // $img_array = glob(STYLESHEETPATH . '/manifest/gallary/*.{gif,jpg,jpeg,png}', GLOB_BRACE);
             // Alpine不支持GLOB_BRACE常量，出于兼容性考虑，不使用glob函数
-            // 自 wordpress 6.4.0 起，弃用了STYLESHEETPATH定义. 为确保子主题能正常使用，应当使用get_template_directory()接口
-            $folderPath = get_template_directory() . '/manifest/gallary/';
+            $folderPath = STYLESHEETPATH . '/manifest/gallary/';
             $allowedExtensions = array('jpg', 'jpeg', 'png', 'gif');
             $img_array = array();
             $files = scandir($folderPath);
@@ -199,7 +198,7 @@ class Images
                 // 检查文件扩展名是否在允许的范围内
                 $extension = strtolower(pathinfo($file, PATHINFO_EXTENSION));
                 if (in_array($extension, $allowedExtensions)) {
-                    $img_array[] =  get_template_directory() . '/manifest/gallary/' . $file;
+                    $img_array[] =  STYLESHEETPATH . '/manifest/gallary/' . $file;
                 }
             }
 
@@ -208,12 +207,12 @@ class Images
             }
             $img = array_rand($img_array);
             $imgurl = trim($img_array[$img]);
-            $imgurl = str_replace(get_template_directory(), get_template_directory_uri(), $imgurl);
+            $imgurl = str_replace(STYLESHEETPATH, get_template_directory_uri(), $imgurl);
         } elseif (iro_opt('random_graphs_options') == 'external_api') {
             $imgurl = iro_opt('random_graphs_link');
         } else {
             // global $sakura_image_array;
-            $temp = file_get_contents(get_template_directory() . "/manifest/manifest.json");
+            $temp = file_get_contents(STYLESHEETPATH . "/manifest/manifest.json");
             // $img_array = json_decode($sakura_image_array, true);
             $img_array = json_decode($temp, true);
             if (!$img_array){
@@ -234,9 +233,9 @@ class Images
 
     public static function mobile_cover_gallery() {
         if (iro_opt('random_graphs_options') == 'local') {
-            // $img_array = glob(get_template_directory() . '/manifest/gallary/*.{gif,jpg,jpeg,png}', GLOB_BRACE);
+            // $img_array = glob(STYLESHEETPATH . '/manifest/gallary/*.{gif,jpg,jpeg,png}', GLOB_BRACE);
             
-            $folderPath = get_template_directory() . '/manifest/gallary/';
+            $folderPath = STYLESHEETPATH . '/manifest/gallary/';
 
             $allowedExtensions = array('jpg', 'jpeg', 'png', 'gif', 'webp');
             $img_array = array();
@@ -246,7 +245,7 @@ class Images
                 // 检查文件扩展名是否在允许的范围内
                 $extension = strtolower(pathinfo($file, PATHINFO_EXTENSION));
                 if (in_array($extension, $allowedExtensions)) {
-                    $img_array[] =  get_template_directory() . '/manifest/gallary/' . $file;
+                    $img_array[] =  STYLESHEETPATH . '/manifest/gallary/' . $file;
                 }
             }
 
@@ -255,13 +254,13 @@ class Images
             }
             $img = array_rand($img_array);
             $imgurl = trim($img_array[$img]);
-            $imgurl = str_replace(get_template_directory(), get_template_directory_uri(), $imgurl);
+            $imgurl = str_replace(STYLESHEETPATH, get_template_directory_uri(), $imgurl);
         } elseif (iro_opt('random_graphs_options') == 'external_api') {
           //$imgurl = iro_opt('random_graphs_link');
            $imgurl = iro_opt('random_graphs_link_mobile');
         } else {
             // global $sakura_mobile_image_array;
-            $temp = file_get_contents(get_template_directory() . '/manifest/manifest_mobile.json');
+            $temp = file_get_contents(STYLESHEETPATH . '/manifest/manifest_mobile.json');
             // $img_array = json_decode($sakura_mobile_image_array, true);
             $img_array = json_decode($temp, true);
             if (!$img_array){

--- a/inc/classes/Images.php
+++ b/inc/classes/Images.php
@@ -190,7 +190,8 @@ class Images
         if (iro_opt('random_graphs_options') == 'local') {
             // $img_array = glob(STYLESHEETPATH . '/manifest/gallary/*.{gif,jpg,jpeg,png}', GLOB_BRACE);
             // Alpine不支持GLOB_BRACE常量，出于兼容性考虑，不使用glob函数
-            $folderPath = STYLESHEETPATH . '/manifest/gallary/';
+            // 自 wordpress 6.4.0 起，弃用了STYLESHEETPATH定义. 为确保子主题能正常使用，应当使用get_template_directory()接口
+            $folderPath = get_template_directory() . '/manifest/gallary/';
             $allowedExtensions = array('jpg', 'jpeg', 'png', 'gif');
             $img_array = array();
             $files = scandir($folderPath);
@@ -198,7 +199,7 @@ class Images
                 // 检查文件扩展名是否在允许的范围内
                 $extension = strtolower(pathinfo($file, PATHINFO_EXTENSION));
                 if (in_array($extension, $allowedExtensions)) {
-                    $img_array[] =  STYLESHEETPATH . '/manifest/gallary/' . $file;
+                    $img_array[] =  get_template_directory() . '/manifest/gallary/' . $file;
                 }
             }
 
@@ -207,12 +208,12 @@ class Images
             }
             $img = array_rand($img_array);
             $imgurl = trim($img_array[$img]);
-            $imgurl = str_replace(STYLESHEETPATH, get_template_directory_uri(), $imgurl);
+            $imgurl = str_replace(get_template_directory(), get_template_directory_uri(), $imgurl);
         } elseif (iro_opt('random_graphs_options') == 'external_api') {
             $imgurl = iro_opt('random_graphs_link');
         } else {
             // global $sakura_image_array;
-            $temp = file_get_contents(STYLESHEETPATH . "/manifest/manifest.json");
+            $temp = file_get_contents(get_template_directory() . "/manifest/manifest.json");
             // $img_array = json_decode($sakura_image_array, true);
             $img_array = json_decode($temp, true);
             if (!$img_array){
@@ -233,9 +234,9 @@ class Images
 
     public static function mobile_cover_gallery() {
         if (iro_opt('random_graphs_options') == 'local') {
-            // $img_array = glob(STYLESHEETPATH . '/manifest/gallary/*.{gif,jpg,jpeg,png}', GLOB_BRACE);
+            // $img_array = glob(get_template_directory() . '/manifest/gallary/*.{gif,jpg,jpeg,png}', GLOB_BRACE);
             
-            $folderPath = STYLESHEETPATH . '/manifest/gallary/';
+            $folderPath = get_template_directory() . '/manifest/gallary/';
 
             $allowedExtensions = array('jpg', 'jpeg', 'png', 'gif', 'webp');
             $img_array = array();
@@ -245,7 +246,7 @@ class Images
                 // 检查文件扩展名是否在允许的范围内
                 $extension = strtolower(pathinfo($file, PATHINFO_EXTENSION));
                 if (in_array($extension, $allowedExtensions)) {
-                    $img_array[] =  STYLESHEETPATH . '/manifest/gallary/' . $file;
+                    $img_array[] =  get_template_directory() . '/manifest/gallary/' . $file;
                 }
             }
 
@@ -254,13 +255,13 @@ class Images
             }
             $img = array_rand($img_array);
             $imgurl = trim($img_array[$img]);
-            $imgurl = str_replace(STYLESHEETPATH, get_template_directory_uri(), $imgurl);
+            $imgurl = str_replace(get_template_directory(), get_template_directory_uri(), $imgurl);
         } elseif (iro_opt('random_graphs_options') == 'external_api') {
           //$imgurl = iro_opt('random_graphs_link');
            $imgurl = iro_opt('random_graphs_link_mobile');
         } else {
             // global $sakura_mobile_image_array;
-            $temp = file_get_contents(STYLESHEETPATH . '/manifest/manifest_mobile.json');
+            $temp = file_get_contents(get_template_directory() . '/manifest/manifest_mobile.json');
             // $img_array = json_decode($sakura_mobile_image_array, true);
             $img_array = json_decode($temp, true);
             if (!$img_array){


### PR DESCRIPTION
在这个PR (https://github.com/mirai-mamori/Sakurairo/pull/1036) 中，修复了使用错误接口导致的子主题创建错误问题。

现在发现，仍有一些未修正的错误。此前发现的错误使用的都是`get_stylesheet_directory()`；而本次发现的则是更旧的接口`STYLESHEETPATH`. 两个接口的行为是一致的，都会导致子主题创建错误。

## 问题描述
当用户从sakurairo创建子主题时，代码会试图从子主题寻找该文件，这会导致找不到文件从而报错。

例如如下代码就是不推荐的：
```php
include(get_stylesheet_directory().'/layouts/all_opt.php');
```
它总是会去找当前主题下的`'/layouts/all_opt.php'`文件。而用户一旦从sakurairo主题创建子主题，它就会尝试寻找子主题下的`'/layouts/all_opt.php'`文件——这个文件不存在于是就报错了。

例如，现在验证码功能中如下代码就是不推荐的：
```php
$font = STYLESHEETPATH . '/inc/KumoFont.ttf';
```
它也总是会去找当前主题下的`'/inc/KumoFont.ttf'`文件，因为相同的原因导致报错。

而期望的行为应该是从父亲主题寻找该文件。

## 改进
所以，这些地方应该使用`get_template_directory`接口。
这两个接口的区别如下：
- `get_stylesheet_directory`，总是返回当前主题的绝对路径，无论是否为子主题。
- `get_template_directory`，如果当前启用的主题是一个子主题，该函数返回父主题的主题目录的服务器绝对路径；否则，返回当前主题的绝对路径。

于是换用该接口后，这些地方总是返回父主题（也即sakurairo主题）的绝对路径。
修复该bug后，可以正常从sakurairo主题创建子主题。

## 弃用的API
此外，`STYLESHEETPATH`和`TEMPLATEPATH`均是弃用的api，均应该换用。
相关定义摘取如下（详情请见wordpress的这个文件：`wp-includes/default-constants.php`）：
```php
/**
* Filesystem path to the current active template directory.
*
* @since 1.5.0
* @deprecated 6.4.0 Use get_template_directory() instead.
* @see get_template_directory()
*/
define( 'TEMPLATEPATH', get_template_directory() );

/**
* Filesystem path to the current active template stylesheet directory.
*
* @since 2.1.0
* @deprecated 6.4.0 Use get_stylesheet_directory() instead.
* @see get_stylesheet_directory()
*/
define( 'STYLESHEETPATH', get_stylesheet_directory() );
```