### PR TITLE
修复不恰当的权限判断

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1988,7 +1988,7 @@ add_action('admin_head', 'custom_admin_open_sans_font');
 // WordPress Custom Font @ Admin Frontend Toolbar
 function custom_admin_open_sans_font_frontend_toolbar()
 {
-    if (current_user_can('administrator') && is_admin_bar_showing()) {
+    if (current_user_can('manage_options') && is_admin_bar_showing()) {
         echo '<link href="https://' . iro_opt('gfonts_api', 'fonts.googleapis.com') . '/css?family=Noto+Serif+SC&display=swap" rel="stylesheet">' . PHP_EOL;
         echo '<style>#wpadminbar *:not([class="ab-icon"]){font-family: "Noto Serif SC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif !important;}</style>' . PHP_EOL;
     }

--- a/inc/theme_plus.php
+++ b/inc/theme_plus.php
@@ -144,7 +144,7 @@ if(iro_opt('not_robot')) add_action('pre_comment_on_post', 'siren_robot_comment'
 function scp_comment_post( $incoming_comment ) {
   // 为什么要拦自己呢？
   global $user_ID; 
-  if( $user_ID && current_user_can('administrator') ) {
+  if( $user_ID && current_user_can('manage_options') ) {
     return( $incoming_comment );
   } elseif(!preg_match('/[一-龥]/u', $incoming_comment['comment_content'])){
     siren_ajax_comment_err('写点汉字吧。You should add some Chinese words.');
@@ -237,7 +237,7 @@ function gopage(url,descr) {
     window.setTimeout(() => { cb(5); }, 1000); //倒计时秒数在这捏
 }
   </script>  
-  <?php if(current_user_can('administrator')){ ?>
+  <?php if(current_user_can('manage_options')){ ?>
   <div class="admin-login-check">
     <?php 
     echo login_ok(); 
@@ -268,7 +268,7 @@ function login_ok(){
   <p id="login-showtime"></p>
   <p class="ex-logout">
     <a href="<?php bloginfo('url'); ?>" title="<?php _e('Home','sakurairo')/*首页*/?>"><?php _e('Home','sakurairo')/*首页*/?></a>
-    <?php if(current_user_can('administrator')){  ?>
+    <?php if(current_user_can('manage_options')){  ?>
     <a href="<?php bloginfo('url'); ?>/wp-admin/" title="<?php _e('Manage','sakurairo')/*后台*/?>" target="_top"><?php _e('Manage','sakurairo')/*后台*/?></a> 
     <?php } ?>
     <a href="<?php echo wp_logout_url(get_bloginfo('url')); ?>" title="<?php _e('Logout','sakurairo')/*登出*/?>" target="_top"><?php _e('Sign out? ','sakurairo')/*登出？*/?></a>
@@ -409,7 +409,7 @@ function header_user_menu()
           <div class="header-user-name-u"><?php echo $current_user->display_name; ?></div>
         </div>
         <div class="user-menu-option">
-          <?php if (current_user_can('administrator')) { ?>
+          <?php if (current_user_can('manage_options')) { ?>
             <a href="<?php bloginfo('url'); ?>/wp-admin/" target="_blank"><?php _e('Dashboard', 'sakurairo')/*管理中心*/ ?></a>
             <a href="<?php bloginfo('url'); ?>/wp-admin/post-new.php" target="_blank"><?php _e('New post', 'sakurairo')/*撰写文章*/ ?></a>
           <?php } ?>
@@ -457,7 +457,7 @@ function m_user_menu()
         <span><?php echo $current_user->display_name; ?></span>
       </div>
       <div class="m-user-menu-option">
-        <?php if (current_user_can('administrator')) { ?>
+        <?php if (current_user_can('manage_options')) { ?>
           <a href="<?php bloginfo('url'); ?>/wp-admin/" target="_blank"><?php _e('Dashboard', 'sakurairo')/*管理中心*/ ?></a>
           <a href="<?php bloginfo('url'); ?>/wp-admin/post-new.php" target="_blank"><?php _e('New post', 'sakurairo')/*撰写文章*/ ?></a>
         <?php } ?>

--- a/search.php
+++ b/search.php
@@ -24,7 +24,7 @@ get_header(); ?>
     if (iro_opt('search_for_pages')) {
         if (iro_opt('only_admin_can_search_pages')) {
             //仅限管理员检索页面
-            if (current_user_can('administrator')) {
+            if (current_user_can('manage_options')) {
                 $default_checked[] = 'page';
             } else {
                 $show_pages_filter = false;
@@ -58,7 +58,7 @@ get_header(); ?>
 
     if (iro_opt('only_admin_can_search_pages')) {
         // 只允许管理员检索页面
-        if (!current_user_can('administrator')) {
+        if (!current_user_can('manage_options')) {
             // 不是管理员就移除page
             $all_results_args['post_type'] = array_diff($content_types, array('page'));
         }


### PR DESCRIPTION
current_user_can() 用于检查权限而非角色。直接使用 'administrator'（角色名）检查会不可靠。
管理员角色的核心权限是 manage_options，其他插件可能修改角色权限关系。