### PR TITLE
一些样式调整

### DIFF
--- a/inc/decorate.php
+++ b/inc/decorate.php
@@ -759,11 +759,7 @@ body.dark .site-branding{
 
 <?php if (iro_opt('exhibition_area_compat', 'true')): ?>
 .the-feature.from_left_and_right {
-    position: relative;
     border-radius: <?=iro_opt('exhibition_radius', ''); ?>px;
-    height: 160px;
-    width: 258px;
-    margin: 6px 6px 0 6px;
 }
 
 .the-feature img {

--- a/style.css
+++ b/style.css
@@ -3777,7 +3777,7 @@ iframe {
   box-shadow: 1px 1px 3px rgba(0, 0, 0, .3);
   overflow: hidden;
   border-radius: 15px;
-  margin: 6px 6.5px 0 6.5px;
+  margin: 6px 3px 0 3px;
 }
 
 .the-feature.from_left_and_right .img {

--- a/style.css
+++ b/style.css
@@ -3514,6 +3514,10 @@ iframe {
   border: 1.5px solid #FFFFFF;
 }
 
+.toc::-webkit-scrollbar-track {
+  margin: 2.5px !important;
+}
+
 .toc:hover {
   box-shadow: 0 1px 20px 10px #e8e8e8;
   background: rgba(255, 255, 255, 0.8);

--- a/style.css
+++ b/style.css
@@ -3494,7 +3494,7 @@ iframe {
   width: 190px;
   height: 100%;
   background-color: rgba(255, 255, 255, 0);
-  right: calc((100% - 1250px)/ 2);
+  right: right: calc((100% - 1220px) / 760 *210*1.6);
   top: 540px;
   position: absolute;
   padding-top: 10px;

--- a/style.css
+++ b/style.css
@@ -3515,7 +3515,7 @@ iframe {
 }
 
 .toc::-webkit-scrollbar-track {
-  margin: 2.5px !important;
+  margin: 1px !important;
 }
 
 .toc:hover {

--- a/style.css
+++ b/style.css
@@ -3293,7 +3293,6 @@ input[type=radio]:checked:before {
 
 iframe {
   aspect-ratio: 16 / 9;
-  height: 100%;
   width: 100%;
 }
 


### PR DESCRIPTION
使用更拟合的算式动态调整目录的位置，确保美观

为目录滑块添加上下边距，在容器圆角的情况下减少出界面积

移除了iframe的高度样式：
https://github.com/mirai-mamori/Sakurairo/issues/1052
已验证b站、网易云外链播放器仍能按预期全宽显示

调整了展示区域内容之间的边距，防止部分情况下挤成两个一排