### PR TITLE
复刻sakura导航栏样式，修改设置项图片采用自定义前端资源路径，新样式和Sakura样式子菜单均可以居中对齐

### DIFF
--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -127,9 +127,13 @@ nav .menu>li .sub-menu li {
 }
 
 .site-header #show-nav {
-    margin-bottom: 20px;
-    margin-left: 0px;
-    margin-right: 8px;
+    margin-bottom: 4px;
+    margin-left: 0px!important;
+    margin-right: 10px;
+}
+
+.searchbox.js-toggle-search i, .bg-switch i{
+    padding: 11px 10px;
 }
 
 .searchbox.js-toggle-search i {
@@ -157,6 +161,7 @@ nav .menu>li .sub-menu li {
 .bg-switch i{
     border: 2px solid transparent;
     border-radius: 10px !important;
+    padding: 11px 9px;
 }
 
 .bg-switch.hide-state {

--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -39,6 +39,10 @@
     border-radius: 0px;
 }
 
+.site-title{
+    display: flex !important;
+}
+
 .site-title-logo {
     display: flex;
     justify-content: center;

--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -5,21 +5,18 @@
     display: flex;
     justify-content: left;
     border-radius: 0px !important;
-    top: 0;
-    left: 0;
     background: transparent;
     position: fixed;
     z-index: 999;
     border-bottom: 1.5px solid transparent;
-    -webkit-transition: all .6s ease;
-    transition: all .6s ease;
+    -webkit-transition: all 1s ease;
+    transition: all 1s ease;
 }
 
 .site-header.bg,
 .site-header:hover {
     background: rgba(255, 255, 255, 0.7);
     border-bottom: 1.5px solid #FFFFFF;
-    width: 100%;
     -webkit-transition: all .6s ease;
     transition: border-bottom 0.6s ease,all .6s ease;
 }

--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -1,0 +1,247 @@
+.site-header {
+    gap: 3px;
+    width: 100%;
+    height: 75px;
+    display: flex;
+    justify-content: left;
+    border-radius: 0px !important;
+    top: 0;
+    left: 0;
+    background: transparent;
+    position: fixed;
+    z-index: 999;
+    border-bottom: 1.5px solid transparent;
+    -webkit-transition: all .6s ease;
+    transition: all .6s ease;
+}
+
+.site-header.bg,
+.site-header:hover {
+    background: rgba(255, 255, 255, 0.7);
+    border-bottom: 1.5px solid #FFFFFF;
+    width: 100%;
+    -webkit-transition: all .6s ease;
+    transition: border-bottom 0.6s ease,all .6s ease;
+}
+
+.site-branding {
+    border-radius: 0px;
+    background: transparent;
+    border: 0px;
+    height: 75px;
+    line-height: 75px;
+    backdrop-filter: none;
+    box-shadow: none;
+}
+
+.site-branding img {
+    max-height: 90px;
+    border-radius: 0px;
+}
+
+.site-title-logo {
+    display: flex;
+    justify-content: center;
+    max-height: none;
+}
+
+.site-branding:hover,
+.site-title,
+.site-title:hover {
+    background-color: transparent;
+}
+
+.site-title {
+    font-size: 38px;
+    transition: all 0.4s ease-in-out;
+}
+
+.site-title:hover {
+    color: var(--theme-skin-matching);
+    background-color: transparent;
+}
+
+.site-title img {
+    margin-top: 17px;
+}
+
+.site-header .menu-wrapper{
+    width: 100%;
+    animation: fadeInLeft 1s;
+}
+
+.menu-wrapper nav.sakura_nav .menu {
+    display: flex;
+    width: 100%;
+}
+
+.menu-wrapper .nav_menu_hide {
+    display: none;
+}
+
+.menu-wrapper .nav_menu_display {
+    display: flex;
+    animation: fadeInLeft .7s;
+}
+
+nav ul,
+nav ul li {
+    cursor: default;
+}
+
+nav ul li {
+    padding: 10px 0;
+    -webkit-transition: all 1s ease;
+    transition: all 1s ease;
+}
+
+nav ul li a:after {
+    content: "";
+    display: block;
+    position: absolute;
+    bottom: -5px;
+    height: 4px;
+    background-color: var(--theme-skin-matching, #505050);
+    width: 100%;
+    border-radius: 30px;
+    max-width: 0;
+    transition: max-width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    -webkit-transition: max-width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+nav ul li>a:hover:after {
+    max-width: 100%;
+}
+
+nav .menu>li .sub-menu {
+    white-space: nowrap;
+    top: 110%;
+}
+
+.sub-menu li a:hover:after {
+    max-width: 0%;
+}
+
+nav .menu>li .sub-menu li {
+    padding: 10px 0;
+}
+
+.site-header #show-nav {
+    margin-bottom: 20px;
+    margin-left: 0px;
+    margin-right: 8px;
+}
+
+.searchbox.js-toggle-search i {
+    margin: 17px 0;
+    border-radius: 10px !important;
+    border: 2px solid transparent;
+    font-size: 18px;
+    font-weight: 900;
+}
+
+.searchbox.js-toggle-search i:hover,
+.bg-switch i:hover {
+    color: var(--theme-skin-matching);
+    border: 2px solid var(--theme-skin-matching);
+    background-color: transparent;
+}
+
+.bg-switch {
+    width: 60px;
+    opacity: 1;
+    transition: width 0.4s ease-in-out, opacity 0.4s ease-in-out;
+    overflow: hidden;
+}
+
+.bg-switch i{
+    border: 2px solid transparent;
+    border-radius: 10px !important;
+}
+
+.bg-switch.hide-state {
+    width: 0;
+    opacity: 0;
+    overflow: hidden;
+}
+
+.header-user-avatar img {
+    max-width: none;
+    box-shadow: none;
+}
+
+.header-user-menu {
+    right: -11px;
+    top: 44px;
+    position: absolute;
+    width: 110px;
+    background: transparent;
+    visibility: hidden;
+    overflow: hidden;
+    box-shadow: none;
+    border-radius: 15px;
+    text-align: center;
+    transition: all 0.5s 0.1s;
+    opacity: 0;
+    transform: translateY(-20px);
+}
+
+
+body.dark .site-header.bg,body.dark .site-header:hover {
+    background-color: rgba(38, 38, 38, 0.8) !important;
+    border-bottom: 1.5px solid #7d7d7d30;
+}
+
+body.dark .site-branding {
+    background: transparent !important;
+    box-shadow: none;
+    border: none;
+}
+
+body.dark .site-header #show-nav .line, body.dark .site-header.bg nav ul li a, 
+body.dark .site-header:hover nav ul li a,
+body.dark .site-header.bg .searchbox.js-toggle-search i, body.dark .site-header.bg .bg-switch i,
+body.dark .site-header:hover .searchbox.js-toggle-search i, body.dark .site-header:hover .bg-switch i{
+    color: #CCCCCC !important;
+}
+
+body.dark .site-header.bg #show-nav .line,body.dark .site-header:hover #show-nav .line{
+    background: #CCCCCC;
+}
+
+body.dark .searchbox.js-toggle-search i:hover, body.dark .bg-switch i:hover {
+    color: var(--theme-skin-dark);
+    border: 2px solid var(--theme-skin-dark);
+}
+
+@keyframes fadeInLeft {
+    0% {
+        -moz-transform: translateX(100%);
+        -ms-transform: translateX(100%);
+        -webkit-transform: translateX(100%);
+        transform: translateX(100%);
+        opacity: 0;
+    }
+
+    50% {
+        -moz-transform: translateX(100%);
+        -ms-transform: translateX(100%);
+        -webkit-transform: translateX(100%);
+        transform: translateX(100%);
+        opacity: 0;
+    }
+
+    100% {
+        -moz-transform: translateX(0%);
+        -ms-transform: translateX(0%);
+        -webkit-transform: translateX(0%);
+        transform: translateX(0%);
+        opacity: 1;
+    }
+    }
+
+    @media (max-width: 860px) {
+    .site-header {
+        height: 60px;
+    }
+}

--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -67,21 +67,12 @@
 
 .site-header .menu-wrapper{
     width: 100%;
-    animation: fadeInLeft 1s;
+    animation: fadeInLeft 1.5s;
 }
 
 .menu-wrapper nav.sakura_nav .menu {
     display: flex;
     width: 100%;
-}
-
-.menu-wrapper .nav_menu_hide {
-    display: none;
-}
-
-.menu-wrapper .nav_menu_display {
-    display: flex;
-    animation: fadeInLeft .7s;
 }
 
 nav ul,
@@ -124,12 +115,6 @@ nav .menu>li .sub-menu {
 
 nav .menu>li .sub-menu li {
     padding: 10px 0;
-}
-
-.site-header #show-nav {
-    margin-bottom: 4px;
-    margin-left: 0px!important;
-    margin-right: 10px;
 }
 
 .searchbox.js-toggle-search i, .bg-switch i{
@@ -203,15 +188,11 @@ body.dark .site-branding {
     border: none;
 }
 
-body.dark .site-header #show-nav .line, body.dark .site-header.bg nav ul li a, 
+body.dark .site-header.bg nav ul li a, 
 body.dark .site-header:hover nav ul li a,
 body.dark .site-header.bg .searchbox.js-toggle-search i, body.dark .site-header.bg .bg-switch i,
 body.dark .site-header:hover .searchbox.js-toggle-search i, body.dark .site-header:hover .bg-switch i{
     color: #CCCCCC !important;
-}
-
-body.dark .site-header.bg #show-nav .line,body.dark .site-header:hover #show-nav .line{
-    background: #CCCCCC;
 }
 
 body.dark .searchbox.js-toggle-search i:hover, body.dark .bg-switch i:hover {

--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -13,10 +13,13 @@
     transition: all 1s ease;
 }
 
+.site-header.bg{
+    border-bottom: 1.5px solid #FFFFFF !important;
+}
+
 .site-header.bg,
 .site-header:hover {
     background: rgba(255, 255, 255, 0.7);
-    border-bottom: 1.5px solid #FFFFFF;
     -webkit-transition: all 1s ease;
     transition: border-bottom 1s ease,all 1s ease;
 }
@@ -182,8 +185,8 @@ nav .menu>li .sub-menu li {
     transform: translateY(-20px);
 }
 
-
-body.dark .site-header.bg,body.dark .site-header:hover {
+body.dark .site-header.bg,
+body.dark .site-header:hover {
     background-color: rgba(38, 38, 38, 0.8) !important;
     border-bottom: 1.5px solid #7d7d7d30;
 }

--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -188,7 +188,7 @@ nav .menu>li .sub-menu li {
 body.dark .site-header.bg,
 body.dark .site-header:hover {
     background-color: rgba(38, 38, 38, 0.8) !important;
-    border-bottom: 1.5px solid #7d7d7d30;
+    border-bottom: 1.5px solid #7d7d7d30 !important;
 }
 
 body.dark .site-branding {

--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -17,8 +17,8 @@
 .site-header:hover {
     background: rgba(255, 255, 255, 0.7);
     border-bottom: 1.5px solid #FFFFFF;
-    -webkit-transition: all .6s ease;
-    transition: border-bottom 0.6s ease,all .6s ease;
+    -webkit-transition: all 1s ease;
+    transition: border-bottom 1s ease,all 1s ease;
 }
 
 .site-branding {

--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -69,14 +69,16 @@
     margin-top: 17px;
 }
 
-.site-header .menu-wrapper{
+.site-header .menu-wrapper,
+.menu-wrapper nav.sakura_nav{
+    display:flex;
     width: 100%;
-    animation: fadeInLeft 1.5s;
 }
 
 .menu-wrapper nav.sakura_nav .menu {
     display: flex;
     width: 100%;
+    animation: fadeInLeft 1.5s;
 }
 
 nav ul,
@@ -143,14 +145,17 @@ nav .menu>li .sub-menu li {
 .bg-switch {
     width: 60px;
     opacity: 1;
-    transition: width 0.4s ease-in-out, opacity 0.4s ease-in-out;
     overflow: hidden;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    transition: all .4s ease-in-out;
+    -webkit-transition: all .4s ease-in-out;
 }
 
 .bg-switch i{
     border: 2px solid transparent;
     border-radius: 10px !important;
-    padding: 11px 9px;
 }
 
 .bg-switch.hide-state {

--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -143,7 +143,7 @@ nav .menu>li .sub-menu li {
 }
 
 .bg-switch {
-    width: 60px;
+    width: 50px;
     opacity: 1;
     overflow: hidden;
     flex: 0 0 auto;

--- a/header.php
+++ b/header.php
@@ -149,6 +149,15 @@ header('X-Frame-Options: SAMEORIGIN');
         </div>
     <?php endif; ?>
     <div class="scrollbar" id="bar"></div>
+
+    <!-- 导航菜单 -->
+     <?php if(iro_opt('nav_menu_style') == 'sakura'){
+        ?>
+        <link rel="stylesheet" href="<?php echo get_template_directory_uri() . '/css/sakura_header.css'; ?>">
+        <?php
+        get_template_part('layouts/' . 'sakura_header');
+     } else {
+    ?>
     <header class="site-header no-select" role="banner">
         <?php
         // Logo Section - Only process if logo or text is configured
@@ -223,6 +232,11 @@ header('X-Frame-Options: SAMEORIGIN');
             </div>
         <?php endif; ?>
     </header>
+    <!-- 导航菜单结束 -->
+     <?php
+     }
+     ?>
+     
     <div class="openNav no-select">
         <div class="iconflat no-select" style="padding: 30px;">
             <div class="icon"></div>

--- a/header.php
+++ b/header.php
@@ -151,7 +151,7 @@ header('X-Frame-Options: SAMEORIGIN');
     <div class="scrollbar" id="bar"></div>
 
     <!-- 导航菜单 -->
-     <?php if(iro_opt('sakura_nav_style')){
+     <?php if(iro_opt('classic_sakura_nav_style')){
         ?>
         <link rel="stylesheet" href="<?php echo get_template_directory_uri() . '/css/sakura_header.css'; ?>">
         <?php

--- a/header.php
+++ b/header.php
@@ -151,7 +151,7 @@ header('X-Frame-Options: SAMEORIGIN');
     <div class="scrollbar" id="bar"></div>
 
     <!-- 导航菜单 -->
-     <?php if(iro_opt('nav_menu_style') == 'sakura'){
+     <?php if(iro_opt('sakura_nav_style')){
         ?>
         <link rel="stylesheet" href="<?php echo get_template_directory_uri() . '/css/sakura_header.css'; ?>">
         <?php

--- a/inc/decorate.php
+++ b/inc/decorate.php
@@ -713,7 +713,7 @@ body.dark .post-title:hover{
 
 <?php 
 // Menu style settings
-$nav_menu_style = iro_opt('nav_menu_style');
+$nav_menu_style = iro_opt('nav_option_distribution');
 $has_user_avatar = iro_opt('nav_menu_user_avatar');
 $has_logo = !empty(iro_opt('iro_logo')) || !empty($nav_text_logo['text']); 
 

--- a/inc/decorate.php
+++ b/inc/decorate.php
@@ -301,8 +301,8 @@ font-family:<?=iro_opt('nav_menu_font'); ?> !important;
 $nav_text_logo = iro_opt('nav_text_logo');
 ?>
 
-.site-title a{
-font-family: '<?php echo $nav_text_logo['font_name']; ?>';
+.site-branding a{
+font-family: <?php echo $nav_text_logo['font_name']; ?> !important;
 }
 
 <?php } ?>

--- a/inc/decorate.php
+++ b/inc/decorate.php
@@ -301,8 +301,8 @@ font-family:<?=iro_opt('nav_menu_font'); ?> !important;
 $nav_text_logo = iro_opt('nav_text_logo');
 ?>
 
-.site-branding a{
-font-family: <?php echo $nav_text_logo['font_name']; ?> !important;
+.site-title a{
+font-family: '<?php echo $nav_text_logo['font_name']; ?>';
 }
 
 <?php } ?>
@@ -713,7 +713,7 @@ body.dark .post-title:hover{
 
 <?php 
 // Menu style settings
-$nav_menu_style = iro_opt('nav_option_distribution');
+$nav_menu_style = iro_opt('nav_menu_style');
 $has_user_avatar = iro_opt('nav_menu_user_avatar');
 $has_logo = !empty(iro_opt('iro_logo')) || !empty($nav_text_logo['text']); 
 

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,3 +1,8 @@
+const nav = document.querySelector('nav');
+if (!nav.classList.contains('sakura_nav')) {
+    init_iro_nav();
+}
+function init_iro_nav() {
 // 导航栏长度限制
     function initNavWidth() {
         const nav = document.querySelector('nav');
@@ -954,7 +959,8 @@ const BrowserDetect = {
     isWebKit: () => {
         return 'WebkitAppearance' in document.documentElement.style;
     }
-};
+}
+};//iro_nav function
 
 //防止子菜单量子叠加
 document.addEventListener("DOMContentLoaded", () => {

--- a/js/nav.js
+++ b/js/nav.js
@@ -1003,13 +1003,9 @@ document.addEventListener("DOMContentLoaded", function () {
         // 设置初始样式
         subMenu.style.transform = `translateY(-10px) translateX(${offsetX}px)`;
 
-        // 鼠标进入和离开事件处理
+        // 鼠标移入时设置偏移量
         MainMenu.addEventListener("mouseenter", () => {
             subMenu.style.transform = `translateY(0) translateX(${offsetX}px)`;
-        });
-
-        MainMenu.addEventListener("mouseleave", () => {
-            subMenu.style.transform = `translateY(-10px) translateX(${offsetX}px)`;
         });
     });
 });

--- a/js/nav.js
+++ b/js/nav.js
@@ -985,3 +985,31 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     });
 });
+
+//子菜单动态偏移对齐
+document.addEventListener("DOMContentLoaded", function () {
+    const subMenus = document.querySelectorAll("nav .menu > li .sub-menu");
+
+    subMenus.forEach(subMenu => {
+        const MainMenu = subMenu.parentElement;
+
+        // 获取渲染后的宽度
+        const MainMenuWidth = MainMenu.getBoundingClientRect().width;
+        const subMenuWidth = subMenu.getBoundingClientRect().width;
+
+        // 偏移计算，确保子菜单居中
+        const offsetX = (subMenuWidth - MainMenuWidth) / 2;
+
+        // 设置初始样式
+        subMenu.style.transform = `translateY(-10px) translateX(${offsetX}px)`;
+
+        // 鼠标进入和离开事件处理
+        MainMenu.addEventListener("mouseenter", () => {
+            subMenu.style.transform = `translateY(0) translateX(${offsetX}px)`;
+        });
+
+        MainMenu.addEventListener("mouseleave", () => {
+            subMenu.style.transform = `translateY(-10px) translateX(${offsetX}px)`;
+        });
+    });
+});

--- a/layouts/sakura_header.php
+++ b/layouts/sakura_header.php
@@ -25,7 +25,7 @@ $nav_text_logo = iro_opt('nav_text_logo');
     margin: 0 <?php echo ($nav_style['option_spacing']??'14px'); //选项间距，用于居中和分散时自定义确保美观?>px;
   }
 
-  <?php 
+  <?php //sakurairo classic 基于 sakura样式再层叠
   if($nav_style['style'] == 'sakurairo') { ?>
   .site-header{
     position: fixed;
@@ -41,12 +41,19 @@ $nav_text_logo = iro_opt('nav_text_logo');
     top: 0!important;
     left: 0!important;
     width: 100% !important;
-    border-bottom: 1.5px solid #FFFFFF !important;
     border-radius: 0 !important;
   }
 
   .site-header:hover{
     top: 2.5%;
+  }
+
+  body.dark .site-header:hover {
+    border-bottom: solid transparent !important;
+  }
+
+  body.dark .site-header.bg{
+    border-bottom: 1.5px solid #7d7d7d30 !important;
   }
   <?php } ?>
 </style>

--- a/layouts/sakura_header.php
+++ b/layouts/sakura_header.php
@@ -24,6 +24,31 @@ $nav_text_logo = iro_opt('nav_text_logo');
   nav ul li {
     margin: 0 <?php echo ($nav_style['option_spacing']??'14px'); //选项间距，用于居中和分散时自定义确保美观?>px;
   }
+
+  <?php 
+  if($nav_style['style'] == 'sakurairo') { ?>
+  .site-header{
+    position: fixed;
+    border-radius: 15px !important;
+    width: 95%;
+    height: 60px;
+    left: 2.5% ;
+    top: 2.5% ;
+    border: 1.5px solid transparent !important;
+  }
+
+  .site-header.bg{
+    top: 0!important;
+    left: 0!important;
+    width: 100% !important;
+    border-bottom: 1.5px solid #FFFFFF !important;
+    border-radius: 0 !important;
+  }
+
+  .site-header:hover{
+    top: 2.5%;
+  }
+  <?php } ?>
 </style>
 
 <header class="site-header no-select" role="banner">

--- a/layouts/sakura_header.php
+++ b/layouts/sakura_header.php
@@ -1,0 +1,134 @@
+<?php
+//Sakura样式导航栏
+?>
+<?php 
+$nav_style = iro_opt('sakura_nav_style');
+$nav_text_logo = iro_opt('nav_text_logo');
+?>
+<style>
+  .site-header.bg,
+  .site-header:hover {
+    backdrop-filter: blur( <?php echo ($nav_style['blurry']??'10'); //模糊度 ?>px);
+  }
+
+  .menu-wrapper .sakura_nav .menu{
+    justify-content: <?php echo ($nav_style['distribution']??'right'); //菜单选项所处位置?>;
+  }
+
+  nav ul li {
+    margin: 0 <?php echo ($nav_style['option_spacing']??'14px'); //选项间距，用于居中和分散时自定义确保美观?>px;
+  }
+</style>
+
+<header class="site-header no-select" role="banner">
+
+  <?php //logo开始
+  if (iro_opt('iro_logo') || !empty($nav_text_logo['text'])): ?>
+    <div class="site-branding">
+      <a href="<?= esc_url(home_url('/')); ?>">
+        <?php if (iro_opt('iro_logo')): ?>
+          <div class="site-title-logo">
+            <img alt="<?= esc_attr(get_bloginfo('name')); ?>"
+              src="<?= esc_url(iro_opt('iro_logo')); ?>"
+              width="auto" height="auto"
+              loading="lazy"
+              decoding="async">
+          </div>
+        <?php endif; ?>
+        <?php if (!empty($nav_text_logo['text'])): ?>
+          <div class="site-title">
+            <?= esc_html($nav_text_logo['text']); ?>
+          </div>
+        <?php endif; ?>
+      </a>
+    </div>
+  <?php endif; //logo结束?>
+
+  <div class="menu-wrapper">
+    <?php //菜单开始
+    $nav_menu_display = $nav_style['fold']; //决定菜单是否展开
+    $container_class = 'sakura_nav';
+    if ($nav_menu_display == 'fold') {
+      $container_class = 'sakura_nav nav_menu_hide';
+    }
+    ?>
+    <?php wp_nav_menu(['depth' => 2, 'theme_location' => 'primary', 'container' => 'nav', 'container_class' => $container_class]); ?>
+  </div>
+  
+  <?php if ($nav_menu_display == 'fold') { ?>
+      <div id="show-nav" class="showNav">
+        <div class="line line1"></div>
+        <div class="line line2"></div>
+        <div class="line line3"></div>
+      </div>
+  <?php } //菜单结束?>
+
+  <?php
+  if (iro_opt('nav_menu_search') == '1') { //是否开启搜索框?>
+    <div class="searchbox js-toggle-search"><i class="fa-solid fa-magnifying-glass"></i></div>
+  <?php } ?>
+
+  <?php $enable_random_graphs = (bool)iro_opt('cover_switch', true) && (bool)iro_opt('cover_random_graphs_switch', true); //是否允许更换背景
+  if ($enable_random_graphs): ?>
+    <div class="bg-switch" id="bg-next">
+      <i class="fa-solid fa-dice" aria-hidden="true"></i>
+      <span class="screen-reader-text">
+        <?php esc_html_e('Random Background', 'sakurairo'); ?>
+      </span>
+    </div>
+    <?php //仅在主页展示背景切换功能 ?>
+    <script>
+      function bgImageSwitcher() {
+        const bgImageSwitcher = document.getElementById('bg-next');
+        if (!bgImageSwitcher) {
+          return;
+        } else {
+          if (window.location.pathname === '/' && !window.location.search){
+            bgImageSwitcher.classList.remove('hide-state');
+          } else {
+            bgImageSwitcher.classList.add('hide-state');
+          }
+        }
+      }
+    bgImageSwitcher()
+    <?php if (iro_opt('poi_pjax')){ //pjax开启时，页面切换后重新加载?>
+      document.addEventListener('pjax:complete', () => {
+      bgImageSwitcher();
+    });
+    <?php } ?>
+    </script>
+  <?php endif; ?>
+
+  <?php header_user_menu(); //用户栏?>
+
+  <script><?php //置顶时添加底色 ?>
+    window.addEventListener('scroll', function() {
+      const header = document.querySelector('.site-header');
+      // 检查位置
+      if (window.scrollY > 0) {
+        header.classList.add('bg');
+      } else {
+        header.classList.remove('bg');
+      }
+    });
+    <?php if ($nav_style['fold'] == 'fold') {  //菜单开关实现?>
+    document.addEventListener('DOMContentLoaded', function() {
+      // 监听#show-Nav的点击事件
+      const showNavBtn = document.getElementById('show-nav');
+      if (showNavBtn) {
+        showNavBtn.addEventListener('click', function() {
+          const menuElement = document.querySelector('.sakura_nav');
+          if (menuElement) {
+            if (menuElement.classList.contains('nav_menu_display')) {
+              menuElement.classList.replace('nav_menu_display', 'nav_menu_hide');
+            } else {
+              menuElement.classList.replace('nav_menu_hide', 'nav_menu_display');
+            }
+          }
+        });
+      }
+    });
+    <?php } ?>
+  </script>
+  
+</header>

--- a/layouts/sakura_header.php
+++ b/layouts/sakura_header.php
@@ -11,8 +11,14 @@ $nav_text_logo = iro_opt('nav_text_logo');
     backdrop-filter: blur( <?php echo ($nav_style['blurry']??'10'); //模糊度 ?>px);
   }
 
+  <?php if (!empty($nav_text_logo['font_name'])){ ?>
+  .site-branding a{
+    font-family: <?php echo $nav_text_logo['font_name']; ?> !important;
+  }
+  <?php } ?>
+
   .menu-wrapper .sakura_nav .menu{
-    justify-content: <?php echo (iro_opt('nav_option_distribution')??'right'); //菜单选项所处位置?>;
+    justify-content: <?php echo ($nav_style['distribution']??'right'); //菜单选项所处位置?>;
   }
 
   nav ul li {
@@ -25,11 +31,11 @@ $nav_text_logo = iro_opt('nav_text_logo');
   <?php //logo开始
   if (iro_opt('iro_logo') || !empty($nav_text_logo['text'])): ?>
     <div class="site-branding">
-      <a href="<?= esc_url(home_url('/')); ?>">
+      <a href="<?php echo esc_url(home_url('/')); ?>">
         <?php if (iro_opt('iro_logo')): ?>
           <div class="site-title-logo">
-            <img alt="<?= esc_attr(get_bloginfo('name')); ?>"
-              src="<?= esc_url(iro_opt('iro_logo')); ?>"
+            <img alt="<?php echo esc_attr(get_bloginfo('name')); ?>"
+              src="<?php echo esc_url(iro_opt('iro_logo')); ?>"
               width="auto" height="auto"
               loading="lazy"
               decoding="async">
@@ -37,7 +43,7 @@ $nav_text_logo = iro_opt('nav_text_logo');
         <?php endif; ?>
         <?php if (!empty($nav_text_logo['text'])): ?>
           <div class="site-title">
-            <?= esc_html($nav_text_logo['text']); ?>
+          <?php echo esc_html($nav_text_logo['text']); ?>
           </div>
         <?php endif; ?>
       </a>

--- a/layouts/sakura_header.php
+++ b/layouts/sakura_header.php
@@ -57,9 +57,7 @@ $nav_text_logo = iro_opt('nav_text_logo');
   
   <?php if ($nav_menu_display == 'fold') { ?>
       <div id="show-nav" class="showNav">
-        <div class="line line1"></div>
-        <div class="line line2"></div>
-        <div class="line line3"></div>
+        <div class="line"></div>
       </div>
   <?php } //菜单结束?>
 

--- a/layouts/sakura_header.php
+++ b/layouts/sakura_header.php
@@ -12,7 +12,7 @@ $nav_text_logo = iro_opt('nav_text_logo');
   }
 
   .menu-wrapper .sakura_nav .menu{
-    justify-content: <?php echo ($nav_style['distribution']??'right'); //菜单选项所处位置?>;
+    justify-content: <?php echo (iro_opt('nav_option_distribution')??'right'); //菜单选项所处位置?>;
   }
 
   nav ul li {
@@ -45,21 +45,8 @@ $nav_text_logo = iro_opt('nav_text_logo');
   <?php endif; //logo结束?>
 
   <div class="menu-wrapper">
-    <?php //菜单开始
-    $nav_menu_display = $nav_style['fold']; //决定菜单是否展开
-    $container_class = 'sakura_nav';
-    if ($nav_menu_display == 'fold') {
-      $container_class = 'sakura_nav nav_menu_hide';
-    }
-    ?>
-    <?php wp_nav_menu(['depth' => 2, 'theme_location' => 'primary', 'container' => 'nav', 'container_class' => $container_class]); ?>
+    <?php wp_nav_menu(['depth' => 2, 'theme_location' => 'primary', 'container' => 'nav', 'container_class' => 'sakura_nav']); //菜单?>
   </div>
-  
-  <?php if ($nav_menu_display == 'fold') { ?>
-      <div id="show-nav" class="showNav">
-        <div class="line"></div>
-      </div>
-  <?php } //菜单结束?>
 
   <?php
   if (iro_opt('nav_menu_search') == '1') { //是否开启搜索框?>
@@ -109,24 +96,6 @@ $nav_text_logo = iro_opt('nav_text_logo');
         header.classList.remove('bg');
       }
     });
-    <?php if ($nav_style['fold'] == 'fold') {  //菜单开关实现?>
-    document.addEventListener('DOMContentLoaded', function() {
-      // 监听#show-Nav的点击事件
-      const showNavBtn = document.getElementById('show-nav');
-      if (showNavBtn) {
-        showNavBtn.addEventListener('click', function() {
-          const menuElement = document.querySelector('.sakura_nav');
-          if (menuElement) {
-            if (menuElement.classList.contains('nav_menu_display')) {
-              menuElement.classList.replace('nav_menu_display', 'nav_menu_hide');
-            } else {
-              menuElement.classList.replace('nav_menu_hide', 'nav_menu_display');
-            }
-          }
-        });
-      }
-    });
-    <?php } ?>
   </script>
-  
+
 </header>

--- a/layouts/sakura_header.php
+++ b/layouts/sakura_header.php
@@ -46,21 +46,21 @@ $nav_text_logo = iro_opt('nav_text_logo');
 
   <div class="menu-wrapper">
     <?php wp_nav_menu(['depth' => 2, 'theme_location' => 'primary', 'container' => 'nav', 'container_class' => 'sakura_nav']); //菜单?>
+
+    <?php
+    if (iro_opt('nav_menu_search') == '1') { //是否开启搜索框?>
+      <div class="searchbox js-toggle-search"><i class="fa-solid fa-magnifying-glass"></i></div>
+    <?php } ?>
+
+    <?php $enable_random_graphs = (bool)iro_opt('cover_switch', true) && (bool)iro_opt('cover_random_graphs_switch', true); //是否允许更换背景
+    if ($enable_random_graphs): ?>
+      <div class="bg-switch" id="bg-next">
+        <i class="fa-solid fa-dice" aria-hidden="true"></i>
+        <span class="screen-reader-text">
+          <?php esc_html_e('Random Background', 'sakurairo'); ?>
+        </span>
+      </div>
   </div>
-
-  <?php
-  if (iro_opt('nav_menu_search') == '1') { //是否开启搜索框?>
-    <div class="searchbox js-toggle-search"><i class="fa-solid fa-magnifying-glass"></i></div>
-  <?php } ?>
-
-  <?php $enable_random_graphs = (bool)iro_opt('cover_switch', true) && (bool)iro_opt('cover_random_graphs_switch', true); //是否允许更换背景
-  if ($enable_random_graphs): ?>
-    <div class="bg-switch" id="bg-next">
-      <i class="fa-solid fa-dice" aria-hidden="true"></i>
-      <span class="screen-reader-text">
-        <?php esc_html_e('Random Background', 'sakurairo'); ?>
-      </span>
-    </div>
     <?php //仅在主页展示背景切换功能 ?>
     <script>
       function bgImageSwitcher() {
@@ -82,7 +82,7 @@ $nav_text_logo = iro_opt('nav_text_logo');
     });
     <?php } ?>
     </script>
-  <?php endif; ?>
+  <?php endif; //选项全在menu-wrapper中，防止bg-switch隐藏宽度变化导致brand缩放?>
 
   <?php header_user_menu(); //用户栏?>
 

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -433,11 +433,24 @@ $prefix = 'iro_options';
         'type'       => 'image_select',
         'title'      => __('Nav Menu Style','sakurairo_csf'),
         'options'    => array(
-          'center' => $vision_resource_basepath . 'options/nav_menu_style_center.webp',
-          'space-between' => $vision_resource_basepath . 'options/nav_menu_style_space.webp',
+          'sakurairo' => $vision_resource_basepath . 'options/nav_menu_style_center.webp',
           'sakura' => $vision_resource_basepath . 'options/nav_menu_style_sakura.webp',
         ),
-        'default'    => 'center'
+        'default'    => 'sakurairo',
+      ),
+
+      array(
+        'id' => 'nav_option_distribution',
+        'type' => 'select',
+        'title' => __('Nav Menu Options Display Method','sakurairo_csf'),
+        'desc' => __('Distribution method of menu options,sakurairo style only support center or Evenly dispersed.','sakurairo_csf'),
+        'options'    => array(
+          'left' => __('Keep to the left','sakurairo_csf'),
+          'right' => __('Keep to the right','sakurairo_csf'),
+          'center' => __('Always centered','sakurairo_csf'),
+          'space-between'  => __('Evenly dispersed','sakurairo_csf'),
+        ),
+        'default'    => 'right',
       ),
 
       array(
@@ -467,18 +480,6 @@ $prefix = 'iro_options';
             'max' => '100',
           ),
           array(
-            'id' => 'distribution',
-            'type' => 'select',
-            'title' => __('Nav Menu Options Display Method','sakurairo_csf'),
-            'desc' => __('Distribution method of menu options','sakurairo_csf'),
-            'options'    => array(
-              'left' => __('Keep to the left','sakurairo_csf'),
-              'right' => __('Keep to the right','sakurairo_csf'),
-              'center' => __('Always centered','sakurairo_csf'),
-              'space-between'  => __('Even distribution','sakurairo_csf'),
-            ),
-          ),
-          array(
             'id' => 'option_spacing',
             'type' => 'slider',
             'title' => __('Menu option left and right spacing','sakurairo_csf'),
@@ -488,22 +489,10 @@ $prefix = 'iro_options';
             'min' => '1',
             'max' => '150',
           ),
-          array(
-            'id'         => 'fold',
-            'type'       => 'radio',
-            'title'      => __('Nav Menu Content Display Method','sakurairo_csf'),
-            'desc'    => __('You can choose to unfold or fold the nav menu contents','sakurairo_csf'),
-            'options'    => array(
-              'unfold' => __('Unfold','sakurairo_csf'),
-              'fold' => __('Fold','sakurairo_csf'),
-            ),
-          ),
         ),
         'default' => array(
           'blurry' => '10',
-          'distribution' => 'right',
           'option_spacing' => '14',
-          'fold' => 'unfold',
         ),
       ),
 

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -433,24 +433,10 @@ $prefix = 'iro_options';
         'type'       => 'image_select',
         'title'      => __('Nav Menu Style','sakurairo_csf'),
         'options'    => array(
-          'sakurairo' => $vision_resource_basepath . 'options/nav_menu_style_center.webp',
-          'sakura' => $vision_resource_basepath . 'options/nav_menu_style_sakura.webp',
+          'center' => $vision_resource_basepath . 'options/nav_menu_style_center.webp',
+          'space-between' => $vision_resource_basepath . '/options/nav_menu_style_space.webp',
         ),
-        'default'    => 'sakurairo',
-      ),
-
-      array(
-        'id' => 'nav_option_distribution',
-        'type' => 'select',
-        'title' => __('Nav Menu Options Display Method','sakurairo_csf'),
-        'desc' => __('Distribution method of menu options,sakurairo style only support center or Evenly dispersed.','sakurairo_csf'),
-        'options'    => array(
-          'left' => __('Keep to the left','sakurairo_csf'),
-          'right' => __('Keep to the right','sakurairo_csf'),
-          'center' => __('Always centered','sakurairo_csf'),
-          'space-between'  => __('Evenly dispersed','sakurairo_csf'),
-        ),
-        'default'    => 'right',
+        'default'    => 'center',
       ),
 
       array(
@@ -461,40 +447,7 @@ $prefix = 'iro_options';
         'unit' => 'px',
         'max' => '50',
         'default' => '50',
-        'dependency' => array( 'nav_menu_style', '!=', 'sakura','','true')
        ),
-
-       array(
-        'id' => 'sakura_nav_style',
-        'type' => 'fieldset',
-        'title' => __('Custom Sakura Nav Styles','sakurairo_csf'),
-        'dependency' => array( 'nav_menu_style', '==', 'sakura', '', 'true' ),
-        'fields' => array(
-          array(
-            'id' => 'blurry',
-            'type' => 'slider',
-            'title' => __('Blur degree','sakurairo_csf'),
-            'step' => '1',
-            'unit' => 'px',
-            'min' => '0',
-            'max' => '100',
-          ),
-          array(
-            'id' => 'option_spacing',
-            'type' => 'slider',
-            'title' => __('Menu option left and right spacing','sakurairo_csf'),
-            'desc'    => __('You can manually adjust the option spacing to achieve more distribution effects, the default is 14','sakurairo_csf'),
-            'step' => '1',
-            'unit' => 'px',
-            'min' => '1',
-            'max' => '150',
-          ),
-        ),
-        'default' => array(
-          'blurry' => '10',
-          'option_spacing' => '14',
-        ),
-      ),
 
       array(
         'id' => 'nav_menu_font',
@@ -558,6 +511,68 @@ $prefix = 'iro_options';
         'title' => __('Nav Menu User Avatar in Mobile','sakurairo_csf'),
         'label'   => __('It is on by default. Click to enter the login interface','sakurairo_csf'),
         'default' => true
+      ),
+
+      array(
+        'id' => 'classic_sakura_nav_style',
+        'type' => 'switcher',
+        'title' => __('Enable Classic Sakura Nav','sakurairo_csf'),
+        'default' => false
+      ),
+
+      array(
+        'id' => 'sakura_nav_style',
+        'type' => 'fieldset',
+        'title' => __('Custom Sakura Nav Styles','sakurairo_csf'),
+        'dependency' => array( 'classic_sakura_nav_style', '==', 'true', '', 'true' ),
+        'fields' => array(
+          array(
+            'id'         => 'style',
+            'type'       => 'image_select',
+            'title'      => __('Sakura Nav Style','sakurairo_csf'),
+            'options'    => array(
+              'sakura' => $vision_resource_basepath . 'options/nav_menu_sakura.webp',
+              'sakurairo' => $vision_resource_basepath . '/options/nav_menu_sakurairo.webp',
+            ),
+            'default'    => 'sakura',
+          ),
+          array(
+            'id' => 'distribution',
+            'type' => 'select',
+            'title' => __('Nav Menu Options Display Method','sakurairo_csf'),
+            'desc' => __('Distribution method of menu options,sakurairo style only support center or Evenly dispersed.','sakurairo_csf'),
+            'options'    => array(
+              'left' => __('Keep to the left','sakurairo_csf'),
+              'right' => __('Keep to the right','sakurairo_csf'),
+              'center' => __('Always centered','sakurairo_csf'),
+              'space-between'  => __('Evenly dispersed','sakurairo_csf'),
+            ),
+          ),
+          array(
+            'id' => 'blurry',
+            'type' => 'slider',
+            'title' => __('Blur degree','sakurairo_csf'),
+            'step' => '1',
+            'unit' => 'px',
+            'min' => '0',
+            'max' => '100',
+          ),
+          array(
+            'id' => 'option_spacing',
+            'type' => 'slider',
+            'title' => __('Menu option left and right spacing','sakurairo_csf'),
+            'desc'    => __('You can manually adjust the option spacing to achieve more distribution effects, the default is 14','sakurairo_csf'),
+            'step' => '1',
+            'unit' => 'px',
+            'min' => '1',
+            'max' => '150',
+          ),
+        ),
+        'default' => array(
+          'distribution'    => 'right',
+          'blurry' => '10',
+          'option_spacing' => '14',
+        ),
       ),
 
     )

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -19,6 +19,8 @@ array(
   "EDIT" => __("Action Edit (only displays while user has sufficient permissions)","sakurairo_csf"),
 ));
 
+$vision_resource_basepath = get_option('iro_options')['vision_resource_basepath'] ?? 'https://s.nmxc.ltd/sakurairo_vision/@2.7/';
+
 $prefix = 'iro_options';
 
   if ( ! function_exists( 'iro_validate_optional_url' ) ) {
@@ -134,7 +136,7 @@ $prefix = 'iro_options';
         'type'  => 'text',
         'title' => __('Site Icon','sakurairo_csf'),
         'desc'   => __('Fill in the address, which decides the icon next to the title above the browser','sakurairo_csf'),
-        'default' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/basic/favicon.ico'
+        'default' => $vision_resource_basepath . 'basic/favicon.ico'
       ),
 
       array(
@@ -303,7 +305,7 @@ $prefix = 'iro_options';
         'type'   => 'text',
         'title'  => __('Occupying SVG while Loading Control Units','sakurairo_csf'),
         'desc'   => __('Fill in the address, which is the SVG displayed when loading control units','sakurairo_csf'),
-        'default' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/load_svg/outload.svg'
+        'default' => $vision_resource_basepath . 'load_svg/outload.svg'
       ),
 
     )
@@ -431,8 +433,9 @@ $prefix = 'iro_options';
         'type'       => 'image_select',
         'title'      => __('Nav Menu Style','sakurairo_csf'),
         'options'    => array(
-          'center' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/nav_menu_style_center.webp',
-          'space-between' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/nav_menu_style_space.webp',
+          'center' => $vision_resource_basepath . 'options/nav_menu_style_center.webp',
+          'space-between' => $vision_resource_basepath . 'options/nav_menu_style_space.webp',
+          'sakura' => $vision_resource_basepath . 'options/nav_menu_style_sakura.webp',
         ),
         'default'    => 'center'
       ),
@@ -444,7 +447,64 @@ $prefix = 'iro_options';
         'desc' => __('Slide to adjust, the recommended value is 50','sakurairo_csf'),
         'unit' => 'px',
         'max' => '50',
-        'default' => '50'
+        'default' => '50',
+        'dependency' => array( 'nav_menu_style', '!=', 'sakura','','true')
+       ),
+
+       array(
+        'id' => 'sakura_nav_style',
+        'type' => 'fieldset',
+        'title' => __('Custom Sakura Nav Styles','sakurairo_csf'),
+        'dependency' => array( 'nav_menu_style', '==', 'sakura', '', 'true' ),
+        'fields' => array(
+          array(
+            'id' => 'blurry',
+            'type' => 'slider',
+            'title' => __('Blur degree','sakurairo_csf'),
+            'step' => '1',
+            'unit' => 'px',
+            'min' => '0',
+            'max' => '100',
+          ),
+          array(
+            'id' => 'distribution',
+            'type' => 'select',
+            'title' => __('Nav Menu Options Display Method','sakurairo_csf'),
+            'desc' => __('Distribution method of menu options','sakurairo_csf'),
+            'options'    => array(
+              'left' => __('Keep to the left','sakurairo_csf'),
+              'right' => __('Keep to the right','sakurairo_csf'),
+              'center' => __('Always centered','sakurairo_csf'),
+              'space-between'  => __('Even distribution','sakurairo_csf'),
+            ),
+          ),
+          array(
+            'id' => 'option_spacing',
+            'type' => 'slider',
+            'title' => __('Menu option left and right spacing','sakurairo_csf'),
+            'desc'    => __('You can manually adjust the option spacing to achieve more distribution effects, the default is 14','sakurairo_csf'),
+            'step' => '1',
+            'unit' => 'px',
+            'min' => '1',
+            'max' => '150',
+          ),
+          array(
+            'id'         => 'fold',
+            'type'       => 'radio',
+            'title'      => __('Nav Menu Content Display Method','sakurairo_csf'),
+            'desc'    => __('You can choose to unfold or fold the nav menu contents','sakurairo_csf'),
+            'options'    => array(
+              'unfold' => __('Unfold','sakurairo_csf'),
+              'fold' => __('Fold','sakurairo_csf'),
+            ),
+          ),
+        ),
+        'default' => array(
+          'blurry' => '10',
+          'distribution' => 'right',
+          'option_spacing' => '14',
+          'fold' => 'unfold',
+        ),
       ),
 
       array(
@@ -695,10 +755,10 @@ $prefix = 'iro_options';
           'star_shaped'  => true,
           'square_shaped'  => true,
           'lemon_shaped'  => true,
-          'img2'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/background/bg1.png',
-          'img3'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/background/bg2.png',
-          'img4' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/background/bg3.png',
-          'img5' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/background/bg4.png',
+          'img2'  => $vision_resource_basepath . 'background/bg1.png',
+          'img3'  => $vision_resource_basepath . 'background/bg2.png',
+          'img4' => $vision_resource_basepath . 'background/bg3.png',
+          'img5' => $vision_resource_basepath . 'background/bg4.png',
         )
       ),
 
@@ -950,7 +1010,7 @@ $prefix = 'iro_options';
         'desc'   => __('Set the background image of your search area. Leave this option blank to display a white background','sakurairo_csf'),
         'dependency' => array( 'nav_menu_search', '==', 'true', '', 'true' ),
         'library'      => 'image',
-        'default'     => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/basic/iloli.gif'
+        'default'     => $vision_resource_basepath . 'basic/iloli.gif'
       ),
 
       array(
@@ -1356,7 +1416,7 @@ $prefix = 'iro_options';
         'type' => 'text',
         'title' => __('Placeholder SVG when loading the next page','sakurairo_csf'),
         'desc' => __('Fill in the address, this is the SVG that will be displayed as a placeholder when the next page is loading','sakurairo_csf'),
-        'default' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/load_svg/ball.svg'
+        'default' => $vision_resource_basepath . 'load_svg/ball.svg'
       ),
 
     )
@@ -1447,8 +1507,8 @@ $prefix = 'iro_options';
         'type' => 'image_select',
         'title' => __('Cover Info Bar Style','sakurairo_csf'),
         'options' => array(
-          'v1' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/infor_bar_style_v1.webp',
-          'v2' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/infor_bar_style_v2.webp',
+          'v1' => $vision_resource_basepath . 'options/infor_bar_style_v1.webp',
+          'v2' => $vision_resource_basepath . 'options/infor_bar_style_v2.webp',
         ),
         'dependency' => array( 
                               array( 'cover_switch', '==', 'true', '', 'true' ),
@@ -1823,10 +1883,10 @@ $prefix = 'iro_options';
         'desc' => __('Select your favorite icon pack. Icon pack references are detailed in the "About Theme" section','sakurairo_csf'),
         'dependency' => array( 'social_area', '==', 'true', '', 'true' ),
         'options'     => array(
-          'display_icon/fluent_design'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/display_icon_fd.gif',
-          'display_icon/muh2'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/display_icon_h2.gif',
-          'display_icon/flat_colorful'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/display_icon_fc.gif',
-          'display_icon/remix_iconfont'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/display_icon_svg.webp',
+          'display_icon/fluent_design'  => $vision_resource_basepath . 'options/display_icon_fd.gif',
+          'display_icon/muh2'  => $vision_resource_basepath . 'options/display_icon_h2.gif',
+          'display_icon/flat_colorful'  => $vision_resource_basepath . 'options/display_icon_fc.gif',
+          'display_icon/remix_iconfont'  => $vision_resource_basepath . 'options/display_icon_svg.webp',
         ),
         'default'     => 'display_icon/fluent_design'
       ),
@@ -2109,7 +2169,7 @@ $prefix = 'iro_options';
         ),
         'desc' => __('Best width 820px, best height 67px','sakurairo_csf'),
         'library' => 'image',
-        'default' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/series/announcement_bg.webp'
+        'default' => $vision_resource_basepath . 'series/announcement_bg.webp'
       ),
 
       array(
@@ -2138,9 +2198,9 @@ $prefix = 'iro_options';
         'title' => __('Bulletin Board Alignment','sakurairo_csf'),
         'dependency' => array( 'bulletin_board', '==', 'true', '', 'true' ),
         'options'     => array(
-          'left'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/announce_text_left.webp',
-          'right'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/announce_text_right.webp',
-          'center'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/announce_text_center.webp',
+          'left'  => $vision_resource_basepath . 'options/announce_text_left.webp',
+          'right'  => $vision_resource_basepath . 'options/announce_text_right.webp',
+          'center'  => $vision_resource_basepath . 'options/announce_text_center.webp',
         ),
         'default'     => 'left'
       ),
@@ -2204,9 +2264,9 @@ $prefix = 'iro_options';
         'type' => 'image_select',
         'title' => __('Area Title Alignment','sakurairo_csf'),
         'options' => array(
-          'left' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/area_title_text_left.webp',
-          'right' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/area_title_text_right.webp',
-          'center' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/area_title_text_center.webp',
+          'left' => $vision_resource_basepath . 'options/area_title_text_left.webp',
+          'right' => $vision_resource_basepath . 'options/area_title_text_right.webp',
+          'center' => $vision_resource_basepath . 'options/area_title_text_center.webp',
         ),
         'default' => 'left'
       ),
@@ -2249,8 +2309,8 @@ $prefix = 'iro_options';
         'title' => __('Display Area Style','sakurairo_csf'),
         'dependency' => array( 'exhibition_area', '==', 'true', '', 'true' ),
         'options' => array(
-          'left_and_right' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/exhibition_area_style_lr.webp',
-          'bottom_to_top' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/exhibition_area_style_ud.webp',
+          'left_and_right' => $vision_resource_basepath . 'options/exhibition_area_style_lr.webp',
+          'bottom_to_top' => $vision_resource_basepath . 'options/exhibition_area_style_ud.webp',
         ),
         'default' => 'left_and_right'
       ),
@@ -2323,19 +2383,19 @@ $prefix = 'iro_options';
     ),
     'default'   => array(
         array(
-            'img' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/series/exhibition1.webp',
+            'img' => $vision_resource_basepath . 'series/exhibition1.webp',
             'title' => 'アンコール',
             'description' => 'ここは夜のない世界',
             'link' => '',
         ),
         array(
-            'img' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/series/exhibition2.webp',
+            'img' => $vision_resource_basepath . 'series/exhibition2.webp',
             'title' => 'ハルジオン',
             'description' => '過ぎてゆく時間の中',
             'link' => '',
         ),
         array(
-            'img' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/series/exhibition3.webp',
+            'img' => $vision_resource_basepath . 'series/exhibition3.webp',
             'title' => 'かいぶつ',
             'description' => '素晴らしき世界に今日も乾杯',
             'link' => '',
@@ -2377,8 +2437,8 @@ $prefix = 'iro_options';
         'title' => __('Article Area Card Design','sakurairo_csf'),
         'desc' => __('You can choose between letter design or ticket design','sakurairo_csf'),
         'options'    => array(
-          'letter' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/post_list_design_letter.webp',
-          'ticket' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/post_list_design_ticket.webp',
+          'letter' => $vision_resource_basepath . 'options/post_list_design_letter.webp',
+          'ticket' => $vision_resource_basepath . 'options/post_list_design_ticket.webp',
         ),
         'default'    => 'letter'
       ),
@@ -2390,8 +2450,8 @@ $prefix = 'iro_options';
         'desc' => __('You can choose between card style or Non-card style','sakurairo_csf'),
         'dependency' => array( 'post_list_design', '==', 'ticket', '', 'true' ),
         'options'    => array(
-          'card' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/post_list_design_ticket.webp',
-          'non-card' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/post_list_design_ticket_2.webp',
+          'card' => $vision_resource_basepath . 'options/post_list_design_ticket.webp',
+          'non-card' => $vision_resource_basepath . 'options/post_list_design_ticket_2.webp',
         ),
         'default'    => 'card'
       ),
@@ -2555,7 +2615,7 @@ $prefix = 'iro_options';
         'title' => __('Page LazyLoad Placeholder SVG','sakurairo_csf'),
         'dependency' => array( 'page_lazyload', '==', 'true', '', 'true' ),
         'desc' => __('Fill in the address, this is the placeholder image that will be displayed when the page LazyLoad is being loaded','sakurairo_csf'),
-        'default' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/load_svg/inload.svg'
+        'default' => $vision_resource_basepath . 'load_svg/inload.svg'
       ),
 
       array(
@@ -2563,7 +2623,7 @@ $prefix = 'iro_options';
         'type' => 'text',
         'title' => __('Page Image Placeholder SVG','sakurairo_csf'),
         'desc' => __('Fill address, this is the SVG that will be displayed as a placeholder when the page image is being loaded','sakurairo_csf'),
-        'default' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/load_svg/inload.svg'
+        'default' => $vision_resource_basepath . 'load_svg/inload.svg'
       ),
 
     )
@@ -2796,9 +2856,9 @@ $prefix = 'iro_options';
 		'type' => 'image_select',
 		'title' => __('Bangumi Template Source', 'sakurairo_csf'),
 		'options' => array(
-			'bilibili' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/bangumi_tep_bili.webp',
-			'myanimelist' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/bangumi_tep_mal.webp',
-      'bangumi' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/bangumi_tep_bangumi.webp'
+			'bilibili' => $vision_resource_basepath . 'options/bangumi_tep_bili.webp',
+			'myanimelist' => $vision_resource_basepath . 'options/bangumi_tep_mal.webp',
+      'bangumi' => $vision_resource_basepath . 'options/bangumi_tep_bangumi.webp'
 		),
 		'default' => 'bilibili'
 	  ),
@@ -2888,9 +2948,9 @@ $prefix = 'iro_options';
         'type' => 'image_select',
         'title' => __('Friend Link Template Unit Alignment','sakurairo_csf'),
         'options'     => array(
-          'left'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/friend_link_left.webp',
-          'right'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/friend_link_right.webp',
-          'center'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/friend_link_center.webp',
+          'left'  => $vision_resource_basepath . 'options/friend_link_left.webp',
+          'right'  => $vision_resource_basepath . 'options/friend_link_right.webp',
+          'center'  => $vision_resource_basepath . 'options/friend_link_center.webp',
         ),
         'default'     => 'left'
       ),
@@ -3191,7 +3251,7 @@ $prefix = 'iro_options';
         'title' => __('Mail Template Featured Image','sakurairo_csf'),
         'desc' => __('Set the background image of your reply email','sakurairo_csf'),
         'library' => 'image',
-        'default' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/series/mail_head.webp'
+        'default' => $vision_resource_basepath . 'series/mail_head.webp'
       ),
 
       array(
@@ -3259,7 +3319,7 @@ $prefix = 'iro_options';
         'desc' => __('Set your login screen background image, leave this option blank to show the default','sakurairo_csf'),
         'dependency' => array( 'custom_login_switch', '==', 'true', '', 'true' ),
         'library'      => 'image',
-        'default'     => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/series/login_background.webp'
+        'default'     => $vision_resource_basepath . 'series/login_background.webp'
       ),
 
       array(
@@ -3278,7 +3338,7 @@ $prefix = 'iro_options';
         'desc' => __('Set your login screen Logo','sakurairo_csf'),
         'dependency' => array( 'custom_login_switch', '==', 'true', '', 'true' ),
         'library' => 'image',
-        'default' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/series/login_logo.webp'
+        'default' => $vision_resource_basepath . 'series/login_logo.webp'
       ),
 
       array(
@@ -3308,7 +3368,7 @@ $prefix = 'iro_options';
         'title' => __('Dashboard Background Image','sakurairo_csf'),
         'desc' => __('Set your dashboard background image, leave this option blank to show white background','sakurairo_csf'),
         'library' => 'image',
-        'default' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/series/admin_background.webp'
+        'default' => $vision_resource_basepath . 'series/admin_background.webp'
       ),
 
       array(
@@ -3316,8 +3376,8 @@ $prefix = 'iro_options';
         'type' => 'image_select',
         'title' => __('Dashboard Options Menu Style','sakurairo_csf'),
         'options' => array(
-          'v1' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/admin_left_style_v1.webp',
-          'v2' => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/admin_left_style_v2.webp',
+          'v1' => $vision_resource_basepath . 'options/admin_left_style_v1.webp',
+          'v2' => $vision_resource_basepath . 'options/admin_left_style_v2.webp',
         ),
         'default' => 'v1'
       ),  
@@ -3881,9 +3941,9 @@ $prefix = 'iro_options';
         'type'        => 'image_select',
         'title' => __('Theme Update Source','sakurairo_csf'),
         'options'     => array(
-          'github'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/update_source_github.webp',
-          'upyun'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/update_source_upyun.webp',
-          'official_building'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/update_source_iro.webp',
+          'github'  => $vision_resource_basepath . 'options/update_source_github.webp',
+          'upyun'  => $vision_resource_basepath . 'options/update_source_upyun.webp',
+          'official_building'  => $vision_resource_basepath . 'options/update_source_iro.webp',
         ),
         'desc' => __('If you are using a server set up in mainland China, please use the Upyun source or the official theme source as your theme update source','sakurairo_csf'),
         'default'     => 'github'
@@ -3955,8 +4015,8 @@ $prefix = 'iro_options';
       'title' => __('Public CDN Basepath','sakurairo_csf'),
       'dependency' => array( 'external_vendor_lib', '==', 'true', '', 'true' ),
       'options'     => array(
-        'https://s.nmxc.ltd/sakurairo/@'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/update_source_upyun.webp',
-        'https://fastly.jsdelivr.net/gh/mirai-mamori/Sakurairo@'  => 'https://s.nmxc.ltd/sakurairo_vision/@2.7/options/update_source_jsd.webp',
+        'https://s.nmxc.ltd/sakurairo/@'  => $vision_resource_basepath . 'options/update_source_upyun.webp',
+        'https://fastly.jsdelivr.net/gh/mirai-mamori/Sakurairo@'  => $vision_resource_basepath . 'options/update_source_jsd.webp',
       ),
       'default'     => 'https://s.nmxc.ltd/sakurairo/@'
     ),

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -545,7 +545,6 @@ $prefix = 'iro_options';
               'left' => __('Keep to the left','sakurairo_csf'),
               'right' => __('Keep to the right','sakurairo_csf'),
               'center' => __('Always centered','sakurairo_csf'),
-              'space-between'  => __('Evenly dispersed','sakurairo_csf'),
             ),
           ),
           array(

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -531,8 +531,8 @@ $prefix = 'iro_options';
             'type'       => 'image_select',
             'title'      => __('Sakura Nav Style','sakurairo_csf'),
             'options'    => array(
-              'sakura' => $vision_resource_basepath . 'options/nav_menu_sakura.webp',
-              'sakurairo' => $vision_resource_basepath . '/options/nav_menu_sakurairo.webp',
+              'sakura' => $vision_resource_basepath . 'options/nav_menu_style_sakura.webp',
+              'sakurairo' => $vision_resource_basepath . '/options/nav_menu_style_sakurairo.webp',
             ),
             'default'    => 'sakura',
           ),

--- a/style.css
+++ b/style.css
@@ -925,67 +925,6 @@ nav .menu > li .sub-menu a {
   width: 130px;
 }
 
-/* 菜单开关样式 */
-#show-nav {
-  position: relative;
-  float: right;
-  margin-left: 25px;
-  display: block;
-  width: 16px;
-  height: 20px;
-  margin-top: 6.5px;
-  cursor: pointer;
-  z-index: 999;
-}
-
-#show-nav .line {
-  position: absolute;
-  top: 7px;
-  left: 100%;
-  width: 16px;
-  margin-left: -12px;
-  height: 2px;
-  background: var(--theme-skin, #505050);
-  -webkit-transition: all .2s ease;
-  transition: all .2s ease;
-}
-
-#show-nav .line:after,
-#show-nav .line:before {
-  transition-duration: .5s;
-  background-color: var(--theme-skin, #505050);
-  position: absolute;
-  content: "";
-  width: 16px;
-  height: 2px;
-  left: 0;
-}
-
-#show-nav.showNav .line:before {
-  top: -8px;
-}
-
-#show-nav.showNav .line:after {
-  top: 8px;
-}
-
-#show-nav.hideNav .line{
-  background-color: transparent !important;
-}
-
-#show-nav.hideNav .line:before {
-  top: 0;
-  transform: rotate(-45deg);
-  -webkit-transform: rotate(-45deg);
-}
-
-#show-nav.hideNav .line:after {
-  top: 0;
-  transform: rotate(45deg);
-  -webkit-transform: rotate(45deg);
-}
-/* 菜单开关结束 */
-
 .site-content {
   max-width: 860px;
   padding: 0 20px;
@@ -7929,7 +7868,6 @@ body.dark h1.fes-title,
 body.dark h1.main-title,
 body.dark #archives-temp h3,
 body.dark #archives-temp h2,
-body.dark #show-nav .line,
 body.dark .linkdes,
 body.dark .entry-content h1,
 body.dark .entry-content h2,

--- a/style.css
+++ b/style.css
@@ -925,13 +925,13 @@ nav .menu > li .sub-menu a {
   width: 130px;
 }
 
-/* 移动端菜单 */
+/* 菜单开关样式 */
 #show-nav {
   position: relative;
   float: right;
   margin-left: 25px;
   display: block;
-  width: 10px;
+  width: 16px;
   height: 20px;
   margin-top: 6.5px;
   cursor: pointer;
@@ -941,14 +941,50 @@ nav .menu > li .sub-menu a {
 #show-nav .line {
   position: absolute;
   top: 7px;
-  left: 50%;
+  left: 100%;
   width: 16px;
   margin-left: -12px;
-  height: 2.5px;
+  height: 2px;
   background: var(--theme-skin, #505050);
   -webkit-transition: all .2s ease;
   transition: all .2s ease;
 }
+
+#show-nav .line:after,
+#show-nav .line:before {
+  transition-duration: .5s;
+  background-color: var(--theme-skin, #505050);
+  position: absolute;
+  content: "";
+  width: 16px;
+  height: 2px;
+  left: 0;
+}
+
+#show-nav.showNav .line:before {
+  top: -8px;
+}
+
+#show-nav.showNav .line:after {
+  top: 8px;
+}
+
+#show-nav.hideNav .line{
+  background-color: transparent !important;
+}
+
+#show-nav.hideNav .line:before {
+  top: 0;
+  transform: rotate(-45deg);
+  -webkit-transform: rotate(-45deg);
+}
+
+#show-nav.hideNav .line:after {
+  top: 0;
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+}
+/* 菜单开关结束 */
 
 .site-content {
   max-width: 860px;
@@ -4847,30 +4883,6 @@ embed,
 iframe,
 object {
   max-width: 100%;
-}
-
-#show-nav.showNav .line1 {
-  top: 15px;
-}
-
-#show-nav.showNav .line3 {
-  top: 23px;
-}
-
-#show-nav.hideNav .line1 {
-  top: 16px;
-  -webkit-transform: rotateZ(45deg);
-  transform: rotateZ(45deg);
-}
-
-#show-nav.hideNav .line2 {
-  opacity: 0;
-}
-
-#show-nav.hideNav .line3 {
-  top: 16px;
-  -webkit-transform: rotateZ(-45deg);
-  transform: rotateZ(-45deg);
 }
 
 .site-main {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/450ee6e2-b573-4c36-83cf-2c539ec6d6e7)
![image](https://github.com/user-attachments/assets/c43cfd4f-67f5-446a-b2a0-d1d1104affd5)
![image](https://github.com/user-attachments/assets/72dc1c9e-8dc1-4fa6-8a7c-233074cd6b71)

https://github.com/user-attachments/assets/fd7090d9-4afc-4309-8794-84100b0aaffe

使用层叠样式的方法部分复刻了Sakura和Sakurairo经典样式导航栏，

使用Sakura样式时nav.js仅加载防止二级菜单叠加的部分，

设置项面板的部分图片现在也可以使用自定义的前端资源路径
