### PR TITLE
修改样式，使Inner和一言打字特效显示完全

### DIFF
--- a/style.css
+++ b/style.css
@@ -7703,9 +7703,8 @@ body:not(.heimu_toggle_on) .new:hover .heimu.off {
     min-width: 50%;
     font-size: 15px;
     line-height: 25px;
-    overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
 	z-index: 9999;
   }
 

--- a/style.css
+++ b/style.css
@@ -2448,7 +2448,7 @@ h1.main-title {
 }
 
 .socialIconTextInner span {
-  color: white;	
+  color: white;
   border-radius: 0;
   padding: 0;
   background: 0 0;
@@ -7705,7 +7705,7 @@ body:not(.heimu_toggle_on) .new:hover .heimu.off {
     line-height: 25px;
     text-overflow: ellipsis;
     white-space: normal;
-	z-index: 9999;
+    z-index: 9999;
   }
 
   .header-info p {


### PR DESCRIPTION
## 修改内容
### 去除`@media (max-width: 860px)`下，`.header-info`的`overflow`属性并将`white-space`属性值设置为`normal`
- 修改前
![4fd5c44326aa4d9f4c0e21a41712238e](https://github.com/user-attachments/assets/347d1fcf-8ef4-4df2-b508-33c1af049d2f)
![22863237805c9aa37dfbb3c624ac02b2](https://github.com/user-attachments/assets/c130614b-0edf-4109-935c-4ecbf455ce7c)
- 修改后
![63356fccf97164d5ff2069368eaebd6d](https://github.com/user-attachments/assets/92b11c43-5d87-420d-8506-ef46713c5d07)
![1622981c225fac581af206524f39230d](https://github.com/user-attachments/assets/3a2418b4-74f4-4097-b510-62376a062f03)