### PR TITLE
修复在top-social的v1中，鼠标在Inner上鬼畜的问题，并去除了深色模式下多余的边角

### DIFF
--- a/style.css
+++ b/style.css
@@ -2364,14 +2364,11 @@ h1.main-title {
 .top-social .inner img {
   background: unset!important;
   border: unset!important;
+  box-shadow: unset!important;
 }
 
-.top-social .inner:hover {
-	pointer-events: none;
-}
-
-.top-social .inner img:hover {
-  pointer-events: none;
+body.dark .top-social .inner img:hover {
+  box-shadow: none!important;
 }
 
 .top-social img,


### PR DESCRIPTION
## 修改内容
### 1、移除`.top-social .inner:hover`与`.top-social .inner img:hover`样式
### 2、增加`body.dark .top-social .inner img:hover`样式
### 3、修改`.top-social .inner img`样式