### PR TITLE
上下篇预览随机图和文章封面统一

### DIFF
--- a/inc/theme_plus.php
+++ b/inc/theme_plus.php
@@ -40,7 +40,7 @@ function get_avatar_profile_url():string{
  * 随机图
  */
 function get_random_bg_url():string{
-  return rest_url('sakura/v1/image/feature').'?'.rand(1,1000);
+  return DEFAULT_FEATURE_IMAGE();
 }
 
 


### PR DESCRIPTION
原内建图床已移除，改为使用functions中的文章卡片封面随机图获取方法