### PR TITLE
评论区优化

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -117,28 +117,47 @@ function get_smilies_panel() {
 				$test = $img->create_captcha_img();
 
 				$captcha_url = rest_url('sakura/v1/captcha/create');
+
+                $captcha_placeholder = __("Click here to show captcha", "sakurairo");
 			
-				$robot_comments = '
+				$comment_captcha = '
 					<label for="captcha" class="comment-captcha">
-						<img id="captchaimg" width="120" height="40" src="' . htmlspecialchars($test['data'], ENT_QUOTES, 'UTF-8') . '">
-						<input type="text" name="yzm" id="yzm" class="input" value="" size="20" tabindex="4" placeholder="请输入验证码">
+						<img id="captchaimg" onclick="refreshCaptcha()" width="120" height="40" style="width: 0px;" src="' . htmlspecialchars($test['data'], ENT_QUOTES, 'UTF-8') . '">
+						<input type="text" onfocus="showCaptcha();" onblur="hideCaptcha()" name="captcha" id="captcha" class="input" value="" size="20" tabindex="4" placeholder="' . $captcha_placeholder . '">
 						<input type="hidden" name="timestamp" value="' . htmlspecialchars($test['time'], ENT_QUOTES, 'UTF-8') . '">
 						<input type="hidden" name="id" value="' . htmlspecialchars($test['id'], ENT_QUOTES, 'UTF-8') . '">
 					</label>
 				<script>
-					const captchaimg = document.getElementById("captchaimg");
-					if (captchaimg) {
-						captchaimg.addEventListener("click", function (e) {
-							fetch("' . addslashes($captcha_url) . '")
-								.then(resp => resp.json())
-								.then(json => {
-									e.target.src = json["data"];
-									document.querySelector("input[name=\'timestamp\']").value = json["time"];
-									document.querySelector("input[name=\'id\']").value = json["id"];
-								})
-								.catch(error => console.error("获取验证码失败:", error));
-						});
-					}
+                    var captchaHideTimeout = null;
+                    var captchaField = document.getElementById("captcha");
+                    var captchaImg = document.getElementById("captchaimg");
+
+                    function showCaptcha() {
+                        captchaField.setAttribute("placeholder", "");
+                        if (captchaHideTimeout) {
+                            clearTimeout(captchaHideTimeout);
+                            captchaHideTimeout = null;
+                        }
+                        captchaImg.style.width = "120px";
+                    }
+
+                    function hideCaptcha() {
+                        captchaHideTimeout = setTimeout(function() {
+                            captchaImg.style.width = "0";
+                            captchaField.setAttribute("placeholder", "'. $captcha_placeholder .'");
+                        }, 5000);
+                    }
+                        
+	                function refreshCaptcha() {
+                        fetch("' . addslashes($captcha_url) . '")
+                            .then(resp => resp.json())
+                            .then(json => {
+                                captchaImg.src = json["data"];
+                                document.querySelector("input[name=\'timestamp\']").value = json["time"];
+                                document.querySelector("input[name=\'id\']").value = json["id"];
+                            })
+                            .catch(error => console.error("获取验证码失败:", error));
+                    };
 				</script>';
 			} else {
 				$robot_comments = null;
@@ -191,7 +210,7 @@ function get_smilies_panel() {
                                     <span class="popuptext" style="margin-left: -55px;width: 110px;">' . __("Advertisement is forbidden 😀", "sakurairo") . '</span>
                                  </div></div>',
                     'qq'     => '<input type="text" placeholder="QQ" name="new_field_qq" id="qq" value="' . esc_attr($comment_author_url) . '" style="display:none" autocomplete="off"/><!--此栏不可见-->',
-					'checks' => '<div class="comment-checks">' . $robot_comments . $private_ms . $mail_notify ,//此处不闭合，和保存信息在一层级一起闭合
+					'checks' => '<div class="comment-checks">' . $comment_captcha . $private_ms . $mail_notify ,//此处不闭合，和保存信息在一层级一起闭合
                 ))
             );
 

--- a/comments.php
+++ b/comments.php
@@ -178,16 +178,17 @@ function get_smilies_panel() {
                 'title_reply_to'    => '<div class="graybar"><i class="fa-regular fa-comment"></i>' . __('Leave a Reply to', 'sakurairo') . ' %s</div>',
                 'cancel_reply_link' => __('Cancel Reply', 'sakurairo'),
                 'label_submit'      => esc_attr(iro_opt('comment_submit_button_text')),
-                'comment_field'     => '<p style="font-style:italic"><a href="https://segmentfault.com/markdown" target="_blank">
-                                            <i class="fa-brands fa-markdown" style="color:var(--article-theme-highlight,var(--theme-skin-matching));"></i>
-                                        </a> Markdown Supported while <i class="fa-solid fa-code"></i> Forbidden</p>
-                                        <div class="comment-textarea">
+                'comment_field'     => '<div class="comment-textarea">
                                             <textarea placeholder="' . esc_attr(iro_opt('comment_placeholder_text')) . '" name="comment" class="commentbody" id="comment" rows="5" tabindex="4"></textarea>
                                             <label class="input-label">' . esc_html(iro_opt('comment_placeholder_text')) . '</label>
                                         </div>
                                         <div id="upload-img-show"></div>',
                 'submit_button'     => '<div class="form-submit">
                                             <input name="submit" type="submit" id="submit" class="submit" value=" ' . esc_attr(iro_opt('comment_submit_button_text')) . ' ">' . $smilies_panel . '
+                                            <label class="markdown-toggle">
+                                                <input type="checkbox" id="enable_markdown" name="enable_markdown">
+                                                <i class="fa-brands fa-markdown"></i>
+                                            </label>
                                         </div>',
                 'comment_notes_after'  => '',
                 'comment_notes_before' => '',

--- a/comments.php
+++ b/comments.php
@@ -171,6 +171,12 @@ function get_smilies_panel() {
             // 调用辅助函数生成表情面板
             $smilies_panel = get_smilies_panel();
 
+            function custom_comment_logged_in_as($defaults) { //移除表头以xx身份登录提示
+                $defaults['logged_in_as'] = '';
+                return $defaults;
+            }
+            add_filter('comment_form_defaults', 'custom_comment_logged_in_as');
+
             $args = array(
                 'id_form'           => 'commentform',
                 'id_submit'         => 'submit',

--- a/functions.php
+++ b/functions.php
@@ -2406,6 +2406,9 @@ function markdown_parser($incoming_comment)
         'ul' => array(),
         'ol' => array(),
         'li' => array(),
+        'p' => array(),
+        'div' => array(),
+        'span' => array(),
     );
     if (preg_match($re, $incoming_comment['comment_content'])) {
         $incoming_comment['comment_content'] = wp_kses($incoming_comment['comment_content'], $allowed_html_content);//移除所有不允许的标签

--- a/functions.php
+++ b/functions.php
@@ -2376,43 +2376,43 @@ function markdown_parser($incoming_comment)
 
     $enable_markdown = isset($_POST['enable_markdown']) ? (bool) $_POST['enable_markdown'] : false;
 
-    $may_script = array(
-        '/<script.*?>.*?<\/script>/is', //<script>标签
-        '/onclick\s*=\s*["\'].*?["\']/is',//onlick属性
-    );
-
-    foreach ($may_script as $pattern) {
-        if (preg_match($pattern, $incoming_comment['comment_content'])) {
-            siren_ajax_comment_err(__('You should not do that!')); //恶意内容警告
-            return ($incoming_comment);
-        }
-    }
-
-    $re = '/<[^>]*>/';
-    $allowed_html_content = array(
-        'a' => array(
-            'href' => array(),
-            'title' => array(),
-            'target' => array('_blank'),
-        ),
-        'b' => array(),
-        'br' => array(),
-        'img' => array(
-            'src' => array(),
-            'alt' => array(),
-            'width' => array(),
-            'height' => array(),
-        ),
-        'code' => array(),
-        'blockquote' => array(),
-        'ul' => array(),
-        'ol' => array(),
-        'li' => array(),
-        'p' => array(),
-        'div' => array(),
-        'span' => array(),
-    );
     if ($enable_markdown) {
+        $may_script = array(
+            '/<script.*?>.*?<\/script>/is', //<script>标签
+            '/onclick\s*=\s*["\'].*?["\']/is',//onlick属性
+        );
+    
+        foreach ($may_script as $pattern) {
+            if (preg_match($pattern, $incoming_comment['comment_content'])) {
+                siren_ajax_comment_err(__('You should not do that!')); //恶意内容警告
+                return ($incoming_comment);
+            }
+        }
+    
+        $re = '/<[^>]*>/';
+        $allowed_html_content = array(
+            'a' => array(
+                'href' => array(),
+                'title' => array(),
+                'target' => array('_blank'),
+            ),
+            'b' => array(),
+            'br' => array(),
+            'img' => array(
+                'src' => array(),
+                'alt' => array(),
+                'width' => array(),
+                'height' => array(),
+            ),
+            'code' => array(),
+            'blockquote' => array(),
+            'ul' => array(),
+            'ol' => array(),
+            'li' => array(),
+            'p' => array(),
+            'div' => array(),
+            'span' => array(),
+        );
         if (preg_match($re, $incoming_comment['comment_content'])) {
             $incoming_comment['comment_content'] = wp_kses($incoming_comment['comment_content'], $allowed_html_content);//移除所有不允许的标签
         }

--- a/functions.php
+++ b/functions.php
@@ -2409,8 +2409,6 @@ function markdown_parser($incoming_comment)
     );
     if (preg_match($re, $incoming_comment['comment_content'])) {
         $incoming_comment['comment_content'] = wp_kses($incoming_comment['comment_content'], $allowed_html_content);//移除所有不允许的标签
-    } else {
-        $incoming_comment['comment_content'] = htmlspecialchars($incoming_comment['comment_content']);//转义所有特殊字符
     }
 
     $column_names = $wpdb->get_row("SELECT * FROM information_schema.columns where 

--- a/inc/theme_plus.php
+++ b/inc/theme_plus.php
@@ -138,11 +138,14 @@ function comment_captcha(){
   if (empty($_POST)) {
     return siren_ajax_comment_err(__('You may post nothing','sakurairo'));
   }
+  if (is_user_logged_in()) { //登录后不需要验证
+    return true;
+  }
   if (!(isset($_POST['captcha']) && !empty(trim($_POST['captcha'])))) {
       return siren_ajax_comment_err(__('Please fill in the captcha answer','sakurairo'));
   }
   if (!isset($_POST['timestamp']) || !isset($_POST['id']) || !preg_match('/^[\w$.\/]+$/', $_POST['id']) || !ctype_digit($_POST['timestamp'])) {
-      return siren_ajax_comment_err(__('You should not do that','sakurairo'));
+      return siren_ajax_comment_err(__('You should not do that!','sakurairo'));
   }
   include_once('inc/classes/Captcha.php');
   $img = new Sakura\API\Captcha;

--- a/inc/theme_plus.php
+++ b/inc/theme_plus.php
@@ -138,7 +138,7 @@ function comment_captcha(){
   if (empty($_POST)) {
     return siren_ajax_comment_err(__('You may post nothing','sakurairo'));
   }
-  if (!(isset($_POST['yzm']) && !empty(trim($_POST['yzm'])))) {
+  if (!(isset($_POST['captcha']) && !empty(trim($_POST['captcha'])))) {
       return siren_ajax_comment_err(__('Please fill in the captcha answer','sakurairo'));
   }
   if (!isset($_POST['timestamp']) || !isset($_POST['id']) || !preg_match('/^[\w$.\/]+$/', $_POST['id']) || !ctype_digit($_POST['timestamp'])) {
@@ -146,7 +146,7 @@ function comment_captcha(){
   }
   include_once('inc/classes/Captcha.php');
   $img = new Sakura\API\Captcha;
-  $check = $img->check_captcha($_POST['yzm'], $_POST['timestamp'], $_POST['id']);
+  $check = $img->check_captcha($_POST['captcha'], $_POST['timestamp'], $_POST['id']);
   if ($check['code'] == 5) {
       return true;
   }

--- a/style.css
+++ b/style.css
@@ -2053,8 +2053,8 @@ nav#comments-navi {
   background: rgba(255, 255, 255, 0.6);
   border-radius: 10px;
   border: 1px solid #FFFFFF;
-  transition: all 0.4s ease-in-out;
-  -webkit-transition: all 0.4s ease-in-out;
+  transition: all 0.4s ease-in-out,height 0s ease-in-out;
+  -webkit-transition: all 0.4s ease-in-out,height 0s ease-in-out;
 }
 
 .comment-respond input {

--- a/style.css
+++ b/style.css
@@ -3668,7 +3668,8 @@ iframe {
 
 /* 表情面板 */
 #emotion-toggle,
-.insert-image-tips{
+.insert-image-tips,
+.markdown-toggle{
   text-align: center;
   width: 45px;
   height: 45px;
@@ -3795,7 +3796,24 @@ iframe {
   background-color: rgba(245, 245, 245, .8);
 }
 /* 表情选区结束 */
+/* markdown按钮 */
+.markdown-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: color 0.3s ease-in-out;
+}
 
+.markdown-toggle input {
+  display: none;
+}
+
+.markdown-toggle input:checked + i {
+  color: var(--article-theme-highlight, var(--theme-skin-matching));
+}
+/* markdown按钮结束 */
 .no-select {
   -webkit-touch-callout: none;
   -webkit-user-select: none;


### PR DESCRIPTION
验证码图片默认隐藏，保持美观

与验证码输入框交互时显示
失焦后隐藏

更新js逻辑，与pjax兼容，不会在重进页面时重复声明导致失效

修复已登录用户需要人机验证的问题

添加markdown开关，启用markdown的会走一遍允许的html标签过滤后解析，未启用的评论将被全部转义

移除表头 “以XX身份登录” 的内容