### PR TITLE
临时粗暴修复了在点击浏览器返回按钮时bg-switch异常消失的问题

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -296,6 +296,8 @@ const handlePageTransition = (isHomePage, state) => {
     if (isHomePage === state.lastPageWasHome) {
         cleanupAnimations();
         DOM.bgNext.style.display = isHomePage ? "block" : "none";
+        DOM.bgNext.style.transform = isHomePage ? "none" : "translateX(20px)";
+        DOM.bgNext.style.opacity = isHomePage ? "1" : "0";
         return;
     }
 


### PR DESCRIPTION
本次改动仅解决在其他页面通过点击浏览器的后退按钮回到首页时`bg-switch`异常消失，鉴于在点击浏览器前进与后退按钮时，导航栏本无动画，因此本次改动也并未添加其他动画，仅对`bg-switch`异常消失进行修复，十分简单粗暴。如果后续可能，则对`nav.js`部分代码进行重写，以此来为导航栏在点击前进与后退按钮时添加动画。