### PR TITLE
改进体验

### DIFF
--- a/css/sakura_header.css
+++ b/css/sakura_header.css
@@ -37,15 +37,16 @@
 .site-title-logo,
 .site-branding img {
     display: flex;
-    max-height: 90%;
+    max-height: 100%;
     border-radius: 0px;
-    height: 90%;
+    height: 100%;
     justify-content: center;
     object-fit: contain;
 }
 
 .site-branding img{
-    max-width: none;
+    max-width: 20vw;
+    max-height: 50px;
 }
 
 .site-title{

--- a/functions.php
+++ b/functions.php
@@ -3045,10 +3045,16 @@ function iro_action_operator()
             echo 'Done!';
             break;
         case 'del_exist_theme':
-            WP_Filesystem();
-            global $wp_filesystem;
-            $wp_filesystem->delete(get_theme_root() . '/Sakurairo', true);
-            wp_redirect(admin_url(), 302); //重载theme_folder_check_on_admin_init流程
+            $current_theme_folder = basename(get_template_directory());
+            if ($current_theme_folder != 'Sakurairo') {
+                WP_Filesystem();
+                global $wp_filesystem;
+                $wp_filesystem->delete(get_theme_root() . '/Sakurairo', true);
+                wp_redirect(admin_url(), 302); //重载theme_folder_check_on_admin_init流程
+            } else {
+                wp_redirect(admin_url(), 302);
+                return;
+            }
     }
 }
 iro_action_operator();

--- a/functions.php
+++ b/functions.php
@@ -1901,12 +1901,18 @@ function theme_folder_check_on_admin_init() {
 
         // 如果目标路径已存在
         if (file_exists($correct_theme_path)) {
-            add_action('admin_notices', function () use ($theme_folder_name, $correct_theme_folder, $user_locale) {
+            if (is_writable($correct_theme_path)) {
+                $is_writable = true;
+            } else {
+                $is_writable = false;
+            }
+            add_action('admin_notices', function () use ($theme_folder_name, $correct_theme_folder, $user_locale,$is_writable) {
                 switch ( $user_locale ) {
                     case 'zh_CN':
                         ?>
                         <div class="notice notice-error is-dismissible">
                             <p><strong>警告：</strong> 当前父主题文件夹名称为 <code><?php echo esc_html( $theme_folder_name ); ?></code>，但目标名称 <code><?php echo esc_html( $correct_theme_folder ); ?></code> 已存在。请手动检查主题文件夹。</p>
+                            <?php if ($is_writable) { ?> <br><a href="/wp-admin/admin.php?iro_act=del_exist_theme" class="page-title-action">点击此处立即删除重名主题</a> <?php } ?>
                         </div>
                         <?php
                         break;
@@ -1914,6 +1920,7 @@ function theme_folder_check_on_admin_init() {
                         ?>
                         <div class="notice notice-error is-dismissible">
                             <p><strong>警告：</strong> 目前父主題資料夾名稱為 <code><?php echo esc_html( $theme_folder_name ); ?></code>，但目標名稱 <code><?php echo esc_html( $correct_theme_folder ); ?></code> 已存在。請手動檢查主題資料夾。</p>
+                            <?php if ($is_writable) { ?> <br><a href="/wp-admin/admin.php?iro_act=del_exist_theme" class="page-title-action">點擊此處立即刪除重名的主題</a> <?php } ?>
                         </div>
                         <?php
                         break;
@@ -1922,6 +1929,7 @@ function theme_folder_check_on_admin_init() {
                         ?>
                         <div class="notice notice-error is-dismissible">
                             <p><strong>警告：</strong> 現在の親テーマフォルダ名は <code><?php echo esc_html( $theme_folder_name ); ?></code> ですが、対象の名前 <code><?php echo esc_html( $correct_theme_folder ); ?></code> は既に存在します。テーマフォルダを手動で確認してください。</p>
+                            <?php if ($is_writable) { ?> <br><a href="/wp-admin/admin.php?iro_act=del_exist_theme" class="page-title-action">ここをクリックして、重複するテーマをすぐに削除します</a> <?php } ?>
                         </div>
                         <?php
                         break;
@@ -1929,6 +1937,7 @@ function theme_folder_check_on_admin_init() {
                         ?>
                         <div class="notice notice-error is-dismissible">
                             <p><strong>Warning:</strong> The current parent theme folder name is <code><?php echo esc_html( $theme_folder_name ); ?></code>, but the target name <code><?php echo esc_html( $correct_theme_folder ); ?></code> already exists. Please manually check the theme folder.</p>
+                            <?php if ($is_writable) { ?> <br><a href="/wp-admin/admin.php?iro_act=del_exist_theme" class="page-title-action">Click here to immediately delete the duplicate theme</a> <?php } ?>
                         </div>
                         <?php
                         break;
@@ -3035,6 +3044,11 @@ function iro_action_operator()
             echo $gallery->webp();
             echo 'Done!';
             break;
+        case 'del_exist_theme':
+            WP_Filesystem();
+            global $wp_filesystem;
+            $wp_filesystem->delete(get_theme_root() . '/Sakurairo', true);
+            wp_redirect(admin_url(), 302); //重载theme_folder_check_on_admin_init流程
     }
 }
 iro_action_operator();

--- a/style.css
+++ b/style.css
@@ -3124,7 +3124,7 @@ iframe {
   height: 100%;
   background-color: rgba(255, 255, 255, 0);
   right: -15vw;
-  top: 540px;
+  top: 240px;
   position: absolute;
   padding-top: 10px;
   padding-bottom: 10px;

--- a/style.css
+++ b/style.css
@@ -3123,7 +3123,7 @@ iframe {
   width: 190px;
   height: 100%;
   background-color: rgba(255, 255, 255, 0);
-  right: calc((100% - 1220px) / 760 *210*1.6);
+  right: -15vw;
   top: 540px;
   position: absolute;
   padding-top: 10px;
@@ -4553,6 +4553,7 @@ object {
 
 .site-main {
   padding: 7.5% 0 0;
+  position: relative;
 }
 
 .feature {


### PR DESCRIPTION
前后对比：

https://github.com/user-attachments/assets/0c0db18e-335e-4a69-907d-8d51b3aa3549


https://github.com/user-attachments/assets/866c66c4-8d4b-4dd7-9c4c-327c93a7b6da


新增一键删除重名主题
<img width="559" alt="1" src="https://github.com/user-attachments/assets/ba771689-1921-4186-b75b-37c190faf1c4" />

调整了Sakura_header的样式，进一步限高限宽
