### PR TITLE
修复了新版导航栏的一些问题

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -466,6 +466,13 @@ const showBgNext = async () => {
         location.pathname === "/" || location.pathname === "/index.php";
     const state = StateManager.getState();
 
+    if (!state.initialized) {
+        const widths = await InitController.init();
+        state.initialized = true;
+        state.measuredWidths = widths;
+        StateManager.setState(state);
+    }
+
     if (state.isTransitioning) {
         // 即使在过渡状态，也要确保在主页时 bg-next 可点击
         if (isHomePage) {
@@ -812,7 +819,15 @@ const addEventListeners = () => {
                 }
             });
         }],
-        ["DOMContentLoaded", initAnimations]
+        ["DOMContentLoaded", initAnimations],
+        ['popstate', () => {
+            const isHomePage = location.pathname === "/" || location.pathname === "/index.php";
+            if (isHomePage) {
+                StateManager.clear();
+                StateManager.init();
+                showBgNext();
+            }
+        }]
     ];
 
     events.forEach(([event, handler]) => {


### PR DESCRIPTION
# 1、浏览器后退时导航栏长度异常
## 现象：
从主页进入文章页面，滚动显示标题，刷新后后退至主页，导航栏长度异常。
## 原因：
刷新后`StateManager`保留非主页状态，浏览器后退未正确重置，导致宽度计算错误。
## 解决方案：
添加`popstate`事件监听器，在后退至主页时重置状态并重新初始化。
## 说明
- `popstate`在浏览器导航时触发。
- 清除并重新初始化`StateManager`以确保在返回主页时获得新状态。
- 调用`showBgNext`以正确显示`bgNext`。
# 2、主页加载早期进入文章页面导航栏长度异常
## 现象：
在主页加载未完成时进入文章页面，导航栏长度异常。
## 原因：
如果主页未完全加载，`StateManager`和宽度未初始化，过渡到文章页面跳过了适当的宽度设置，导致`navSearchWrapper`保留未调整的宽度。
## 解决方案：
确保`InitController`在页面过渡前完成初始化。
## 说明
- 将初始化移到顶部，确保在任何逻辑之前运行。
- 使用`state`中存储的`measuredWidths`保持一致性。
- 通过依赖`InitController`的稳健测量简化逻辑，防止未初始化的过渡。