### PR TITLE
纠正wechat_copy_switch与qq_copy_switch的默认值

### DIFF
--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -1912,7 +1912,7 @@ $prefix = 'iro_options';
         'title' => __('Click to Copy WeChat ID', 'sakurairo_csf'),
         'dependency' => array('social_area', '==', 'true', '', 'true'),
         'label' => __('Enabled by default, clicking the WeChat icon will copy your WeChat ID instead of opening a link', 'sakurairo_csf'),
-        'default' => false,
+        'default' => true,
       ),
 		
       array(
@@ -1958,7 +1958,7 @@ $prefix = 'iro_options';
         'title' => __('Click to Copy QQ ID', 'sakurairo_csf'),
         'dependency' => array('social_area', '==', 'true', '', 'true'),
         'label' => __('Enabled by default, clicking the QQ icon will copy your QQ ID instead of opening a link', 'sakurairo_csf'),
-        'default' => false,
+        'default' => true,
       ),
 		
       array(


### PR DESCRIPTION
`wechat_copy_switch`与`qq_copy_switch`应为默认开启。