### PR TITLE
问题修复

### DIFF
--- a/inc/decorate.php
+++ b/inc/decorate.php
@@ -379,6 +379,7 @@ background-color: rgba(255, 255, 255,var(--front_background-transparency,<?=iro_
 border-radius: <?=iro_opt('signature_radius'); ?>px;
 }
 
+.top-social i,
 .focusinfo img{
 border-radius: <?=iro_opt('social_area_radius'); ?>px;
 }

--- a/style.css
+++ b/style.css
@@ -2492,6 +2492,7 @@ h1.main-title {
 
 .top-social_v2 i {
   font-size: 28px;
+  color: var(--theme-skin-matching);
 }
 
 .top-social li,


### PR DESCRIPTION
封面社交栏智慧取色icon-font圆角补充

没有给v2加，因为v2在里面，而且颜色是一样的，看不出有圆角

统一了v1v2的智慧取色为matching_color