### PR TITLE
feat: 为文章页的h2标题添加主题统一的装饰样式

### DIFF
--- a/css/content-style/sakura.css
+++ b/css/content-style/sakura.css
@@ -64,6 +64,34 @@
     position: relative
 }
 
+.entry-content h2 {
+    padding-left: 0px;
+    padding-bottom: 0px;
+    position: relative;
+    display: inline-block;
+}
+
+.entry-content h2:after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 30%;
+    right: 0;
+    width: 70%;
+    height: 0.7em;
+    background-color: var(--article-theme-highlight,var(--theme-skin-matching));
+    opacity: 0.4;
+    z-index: 0;
+    border-radius: 30px;
+    transition: all 0.3s ease;
+}
+
+.entry-content h2:hover:after {
+	width: 85%;
+  	left: 15%;
+	opacity: 0.7;
+}
+
 .entry-content h3,
 .entry-content h4,
 .entry-content h5 {


### PR DESCRIPTION
现在文章页的h2标题也有了主题统一的动态响应式装饰样式，且支持文章自动取色

![image](https://github.com/user-attachments/assets/056f21aa-0005-4617-9427-ed198d81d2c6)
