### PR TITLE
fix: 修复页码样式遗漏，优化<ul><ol>的list项目编号

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,6 +33,15 @@ li,ul,ol {
   padding-inline-start: unset;
 }
 
+ol.toc-list {
+  list-style-type: none; 
+  counter-reset: none;
+}
+
+ol.toc-list li {
+  counter-increment: none;
+}
+
 ul.commentwrap,
 li.comment,
 ul.search-no-reasults,

--- a/style.css
+++ b/style.css
@@ -2516,6 +2516,7 @@ h1.main-title {
   height: 35px;
   cursor: pointer;
   user-select: none;
+  text-align: center;
 }
 
 .slider-wrapper {

--- a/style.css
+++ b/style.css
@@ -5100,7 +5100,7 @@ span.page-numbers.current {
   margin: 30px 10px;
 }
 
-a.page-numbers {
+span.page-numbers.dots, a.page-numbers {
   color: #ABABAB;
   padding: 0 5px;
   margin: 30px 10px;

--- a/style.css
+++ b/style.css
@@ -29,7 +29,6 @@ i,i:hover{
 }
 
 li,ul,ol {
-  list-style: none;
   cursor: pointer;
   padding-inline-start: unset;
 }

--- a/style.css
+++ b/style.css
@@ -39,6 +39,7 @@ ul.search-no-reasults,
 ul.search-no-reasults li,
 ul.menu-list{
   cursor: unset;
+  list-style-type: none; 
 }
 
 img {


### PR DESCRIPTION
- 优化了页码的省略号显示
![image](https://github.com/user-attachments/assets/b5070368-74b3-49ee-b257-576dbca7347c)

- 恢复了列表项的项目编号，同时优化了使用 `<ul>` `<ol>` 构建的组件无项目编号冲突
![image](https://github.com/user-attachments/assets/6a539019-df5a-4193-be45-c7f32e0a1dbb)
