### PR TITLE
正文分割线样式使用wordpress编辑器样式的不使用主题样式

### DIFF
--- a/css/content-style/sakura.css
+++ b/css/content-style/sakura.css
@@ -141,7 +141,7 @@ h1.entry-title {
     line-height: 30px
 }
 
-.entry-content hr {
+.entry-content hr:not(.wp-block-separator) {
     margin-top: 40px;
     margin-bottom: 40px;
     display: block;
@@ -150,7 +150,7 @@ h1.entry-title {
     background: 0 0
 }
 
-.entry-content hr:before {
+.entry-content hr:before:not(.wp-block-separator) {
     content: '...';
     display: inline-block;
     margin-left: .6em;


### PR DESCRIPTION
wordpress编辑器自带三种分割线样式，包含主题已有的点状分割线