### PR TITLE
修正random_graphs_options选项的条件

### DIFF
--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -1652,7 +1652,7 @@ $prefix = 'iro_options';
         'desc' => __('Fill in an URL','sakurairo_csf'),
         'dependency' => array( 
                               array( 'cover_switch', '==', 'true', '', 'true' ),
-                              array( 'random_graphs_options', '!=', 'local', '', 'true' ),
+                              array( 'random_graphs_options', '!=', 'gallery', '', 'true' ),
                         ),
         'default' => 'https://api.fuukei.org/random-img/default/pc.php',
         'sanitize' => false,
@@ -1666,7 +1666,7 @@ $prefix = 'iro_options';
         'dependency' => array( 
                               array( 'random_graphs_mts', '==', 'true' ),
                               array( 'cover_switch', '==', 'true', '', 'true' ),
-                              array( 'random_graphs_options', '!=', 'local', '', 'true' ),
+                              array( 'random_graphs_options', '!=', 'gallery', '', 'true' ),
                         ),
         'desc' => __('Fill in an URL','sakurairo_csf'),
         'default' => 'https://api.fuukei.org/random-img/default/mobile.php',


### PR DESCRIPTION
在原来1617行，设置了内建API的值是gallery，但是在random_graphs_link和random_graphs_link_mobile使用的仍然是local，这样导致当选择内建API的时候仍需要填写外部API的地址。