### PR TITLE
fix: 导航菜单用户头像菜单显示控制失效 #1299

### DIFF
--- a/layouts/sakura_header.php
+++ b/layouts/sakura_header.php
@@ -8,6 +8,7 @@ if (!defined('ABSPATH')) {
 $nav_style = iro_opt('sakura_nav_style');
 $nav_text_logo = iro_opt('nav_text_logo');
 $show_search = (bool)iro_opt('nav_menu_search');
+$show_user_avatar = (bool)iro_opt('nav_user_menu',true);
 ?>
 <style>
   <?php if (!empty($nav_text_logo['font_name'])){ ?>
@@ -157,7 +158,11 @@ $show_search = (bool)iro_opt('nav_menu_search');
 
   <?php get_template_part('layouts/mo_toc_menu');?> 
 
-  <?php header_user_menu(); //用户栏?>
+  <?php
+    if ($show_user_avatar) {
+        header_user_menu(); //用户栏
+    }
+  ?>
 
   <script><?php //置顶时添加底色 ?>
     document.addEventListener('DOMContentLoaded', function(){


### PR DESCRIPTION
**问题出处：**

导航栏

**实际行为描述：**

当**导航菜单样式**设置为第二种时，**导航栏用户头像菜单**开关失效

**预期的行为：**

**导航栏用户头像菜单**开关控制导航是否显示用户头像菜单

**复现步骤：**

**导航菜单样式**设置为**第二种**时，**导航栏用户头像菜单**始终显示无法关闭