### PR TITLE
修复ai总结自动生成设置关闭时，ai总结不显示的问题

### DIFF
--- a/inc/chatgpt/hooks.php
+++ b/inc/chatgpt/hooks.php
@@ -39,16 +39,18 @@ namespace IROChatGPT {
                     }
                 }
             }, 10, 3);
-            add_filter('the_excerpt', function (string $post_excerpt) {
-                global $post;
-                if (has_excerpt($post)) {
-                    return $post_excerpt;
-                } else {
-                    $ai_excerpt =  get_post_meta($post->ID, "ai_summon_excerpt", true);
-                    return $ai_excerpt ? $ai_excerpt : $post_excerpt;
-                }
-            });
         }
+
+        add_filter('the_excerpt', function (string $post_excerpt) {
+            global $post;
+            if (has_excerpt($post)) {
+                return $post_excerpt;
+            } else {
+                $ai_excerpt =  get_post_meta($post->ID, "ai_summon_excerpt", true);
+                return $ai_excerpt ? $ai_excerpt : $post_excerpt;
+            }
+        });
+        
     }
 
     function summon_article_excerpt(WP_Post $post)


### PR DESCRIPTION
pr #1289里为文章总结添加了专门的管理页面，chatgpt_article_summarize开关改成了，chatgpt_auto_article_summarize开关，但是还有处逻辑没有更改