### PR TITLE
修正在未开启导航栏搜索时会报错的情况

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -1387,18 +1387,19 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     //自动收起搜索界面
-    var moSearcgInput = document.querySelector(".mo-menu-search .search-input");
-    function moSearchClose () {
-        moSearcgInput.blur();
-        closeMenu(moNavMenu, moNavButton);
+    let moSearchInput = document.querySelector(".mo-menu-search .search-input");
+    if (moSearchInput) {
+        function moSearchClose () {
+            moSearchInput.blur();
+            closeMenu(moNavMenu, moNavButton);
+        }
+        moSearchInput.addEventListener("focus", function() {
+            document.addEventListener('pjax:complete', moSearchClose);
+        });
+        moSearchInput.addEventListener("blur", function() {
+            document.removeEventListener("pjax:complete", moSearchClose);
+        });
     }
-    moSearcgInput.addEventListener("focus", function() {
-        document.addEventListener('pjax:complete', moSearchClose);
-    });
-    moSearcgInput.addEventListener("blur", function() {
-        document.removeEventListener("pjax:complete", moSearchClose);
-    });
-
 
     //下面是自动收起、展开导航栏部分
     let lastScrollTop = 0;


### PR DESCRIPTION
移动端导航栏搜索后自动收起的部分没有做检查，

导致在没有开启导航栏搜索的情况下控制台会异常报错