### PR TITLE
wordpress6.9兼容

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -192,7 +192,7 @@ function get_smilies_panel() {
                                         </div>',
                 'comment_notes_after'  => '',
                 'comment_notes_before' => '',
-                'fields'            => apply_filters('comment_form_default_fields', array(
+                'fields'            => (!is_user_logged_in()?apply_filters('comment_form_default_fields', array(
                     'avatar' => '<div class="cmt-info-container"><div class="comment-user-avatar">
                                     <img alt="comment_user_avatar" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48IS0tIUZvbnQgQXdlc29tZSBGcmVlIDYuNy4yIGJ5IEBmb250YXdlc29tZSAtIGh0dHBzOi8vZm9udGF3ZXNvbWUuY29tIExpY2Vuc2UgLSBodHRwczovL2ZvbnRhd2Vzb21lLmNvbS9saWNlbnNlL2ZyZWUgQ29weXJpZ2h0IDIwMjUgRm9udGljb25zLCBJbmMuLS0+PHBhdGggZmlsbD0iIzgwODA4MCIgZD0iTTM5OSAzODQuMkMzNzYuOSAzNDUuOCAzMzUuNCAzMjAgMjg4IDMyMGwtNjQgMGMtNDcuNCAwLTg4LjkgMjUuOC0xMTEgNjQuMmMzNS4yIDM5LjIgODYuMiA2My44IDE0MyA2My44czEwNy44LTI0LjcgMTQzLTYzLjh6TTAgMjU2YTI1NiAyNTYgMCAxIDEgNTEyIDBBMjU2IDI1NiAwIDEgMSAwIDI1NnptMjU2IDE2YTcyIDcyIDAgMSAwIDAtMTQ0IDcyIDcyIDAgMSAwIDAgMTQ0eiIvPjwvc3ZnPg==">
                                     <div class="socila-check qq-check"><i class="fa-brands fa-qq fa-xs"></i></div>
@@ -212,7 +212,7 @@ function get_smilies_panel() {
                                  </div></div>',
                     'qq'     => '<input type="text" placeholder="QQ" name="new_field_qq" id="qq" value="' . esc_attr($comment_author_url) . '" style="display:none" autocomplete="off"/><!--此栏不可见-->',
 					'checks' => '<div class="comment-checks">' . ($comment_captcha ?? '') . ($private_ms ?? '') . ($mail_notify ?? '') ,//此处不闭合，和保存信息在一层级一起闭合
-                ))
+                )):[]) // 用户登录则不显示任何字段
             );
 
 			function comment_cookies_check_lable($field) {

--- a/functions.php
+++ b/functions.php
@@ -548,16 +548,6 @@ function sakura_scripts()
             wp_enqueue_style('sakura_header', $core_lib_basepath . '/css/sakura_header.css', array(), IRO_VERSION);
         }
     }
-    if(iro_opt("poi_pjax",true)==true){
-        // 禁用wp6.9按需加载
-        add_filter( 'wp_should_load_separate_core_block_assets', '__return_false' );
-
-        // 全量加载wordpress区块和原生组件样式
-        wp_enqueue_style( 'wp-block-library' );
-        wp_enqueue_style( 'wp-block-library-theme' );
-        wp_enqueue_style( 'wp-block-library-comments' );
-        wp_enqueue_style( 'wp-block-library-widgets' );
-    }
 
     if(!is_404()){
         wp_enqueue_script('app', $core_lib_basepath . '/js/app.js', array('polyfills'), IRO_VERSION, true);
@@ -618,6 +608,22 @@ function sakura_scripts()
     }
 }
 add_action('wp_enqueue_scripts', 'sakura_scripts');
+
+add_action("after_setup_theme",function(){
+    if(iro_opt("poi_pjax",true)==true){
+        // 禁用wp6.9按需加载
+        add_filter( 'wp_should_load_separate_core_block_assets', '__return_false' );
+        add_filter( 'should_load_separate_core_block_assets', '__return_false', 1 );
+        add_filter( 'should_load_block_assets_on_demand', '__return_false', 1 );
+        add_filter( 'enqueue_empty_block_content_assets', '__return_true' );
+
+        // 全量加载wordpress区块和原生组件样式
+        wp_enqueue_style( 'wp-block-library' );
+        wp_enqueue_style( 'wp-block-library-theme' );
+        wp_enqueue_style( 'wp-block-library-comments' );
+        wp_enqueue_style( 'wp-block-library-widgets' );
+    }
+});
 
 /**
  * load .php.

--- a/functions.php
+++ b/functions.php
@@ -525,6 +525,7 @@ function sakura_scripts()
             echo '<link rel="preload" href="' .$iro_css. '" as="style" onload="this.onload=null;this.rel=\'stylesheet\'">';
             echo '<link rel="stylesheet" href="' . $iro_css . '">';
         }, 9);
+
     } else {        
         wp_enqueue_style('iro-css', $core_lib_basepath . '/style.css', array(), IRO_VERSION);
         wp_enqueue_style('iro-codes', $core_lib_basepath . '/css/shortcodes.css', array(), IRO_VERSION);
@@ -546,6 +547,16 @@ function sakura_scripts()
         if(iro_opt('choice_of_nav_style') == 'sakura'){
             wp_enqueue_style('sakura_header', $core_lib_basepath . '/css/sakura_header.css', array(), IRO_VERSION);
         }
+    }
+    if(iro_opt("poi_pjax",true)==true){
+        // 禁用wp6.9按需加载
+        add_filter( 'wp_should_load_separate_core_block_assets', '__return_false' );
+
+        // 全量加载wordpress区块和原生组件样式
+        wp_enqueue_style( 'wp-block-library' );
+        wp_enqueue_style( 'wp-block-library-theme' );
+        wp_enqueue_style( 'wp-block-library-comments' );
+        wp_enqueue_style( 'wp-block-library-widgets' );
     }
 
     if(!is_404()){


### PR DESCRIPTION
现在在启用pjax后会全量加载wordpress区块样式，防止pjax加载后在内容页无法正确显示使用区块编辑器的内容样式
https://github.com/mirai-mamori/Sakurairo/issues/1349
使用三元表达式，根据用户登录状态决定是否显示身份验证字段，在wordpress6.9仍然能正确显示相关字段
https://github.com/mirai-mamori/Sakurairo/issues/1348