### PR TITLE
修改与增强，已登录用户发送成功的评论卡片头像与昵称跳转到评论者的个人主页，让说说拥有与文章一样的默认文章分类

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -381,6 +381,32 @@ function save_emotion_meta_box($post_id) {
 }
 add_action('save_post', 'save_emotion_meta_box');
 
+// Set default category for new shuoshuo
+function set_default_shuoshuo_category($post_id) {
+    // Check if this is a shuoshuo post
+    if (get_post_type($post_id) !== 'shuoshuo') {
+        return;
+    }
+    
+    // Check if this is an autosave
+    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        return;
+    }
+    
+    // Check if the post already has categories
+    $categories = wp_get_post_categories($post_id);
+    if (!empty($categories)) {
+        return;
+    }
+    
+    // Get the default shuoshuo category from theme options
+    $default_category = iro_opt('default_shuoshuo_category');
+    if (!empty($default_category)) {
+        wp_set_post_categories($post_id, array($default_category));
+    }
+}
+add_action('save_post', 'set_default_shuoshuo_category');
+
 function register_custom_meta_boxes() {
     register_meta('post', 'title_style', array(
         'show_in_rest' => true,

--- a/functions.php
+++ b/functions.php
@@ -680,13 +680,13 @@ if (!function_exists('akina_comment_format')) {
                 <div class="comment-arrow">
                     <div class="main shadow">
                         <div class="profile">
-                            <a href="<?php comment_author_url(); ?>" target="_blank" rel="nofollow"><?php echo str_replace('src=', 'src="' . iro_opt('load_in_svg') . '" onerror="imgError(this,1)" data-src=', get_avatar($comment->comment_author_email, 80, '', get_comment_author(), array('class' => array('lazyload')))); ?></a>
+                            <a href="<?php echo $comment->user_id ? get_author_posts_url($comment->user_id) : comment_author_url(); ?>" target="_blank" rel="nofollow"><?php echo str_replace('src=', 'src="' . iro_opt('load_in_svg') . '" onerror="imgError(this,1)" data-src=', get_avatar($comment->comment_author_email, 80, '', get_comment_author(), array('class' => array('lazyload')))); ?></a>
                         </div>
                         <div class="commentinfo">
                             <section class="commeta">
                                 <div class="left">
                                     <h4 class="author">
-                                        <a href="<?php comment_author_url(); ?>" target="_blank" rel="nofollow"><?php echo get_avatar($comment->comment_author_email, 24, '', get_comment_author()); ?>
+                                        <a href="<?php echo $comment->user_id ? get_author_posts_url($comment->user_id) : comment_author_url(); ?>" target="_blank" rel="nofollow"><?php echo get_avatar($comment->comment_author_email, 24, '', get_comment_author()); ?>
                                             <span class="bb-comment isauthor" title="<?php _e('Author', 'sakurairo'); ?>"><?php _e('Blogger', 'sakurairo'); /*博主*/?></span>
                                             <?php comment_author(); ?><?php echo get_author_class($comment->comment_author_email, $comment->user_id); ?>
                                         </a>

--- a/opt/languages/zh_CN.po
+++ b/opt/languages/zh_CN.po
@@ -4446,3 +4446,11 @@ msgstr ""
 #. Author URI of the plugin/theme
 msgid "https://github.com/Fuukei"
 msgstr ""
+
+#: options/theme-options.php:2474
+msgid "Default shuoshuo category"
+msgstr "默认说说分类"
+
+#: options/theme-options.php:2475
+msgid "Select the default category for new shuoshuo"
+msgstr "与默认文章分类一样，为说说选择默认分类"

--- a/opt/options/theme-options.php
+++ b/opt/options/theme-options.php
@@ -2468,6 +2468,15 @@ $prefix = 'iro_options';
         'default' => true
       ),
 
+      array(
+        'id' => 'default_shuoshuo_category',
+        'type' => 'select',
+        'title' => __('Default shuoshuo category','sakurairo_csf'),
+        'desc' => __('Select the default category for new shuoshuo','sakurairo_csf'),
+        'options' => 'categories',
+        'default' => ''
+      ),
+
     )
   ) );
 


### PR DESCRIPTION
<img width="1495" height="726" alt="image" src="https://github.com/user-attachments/assets/8cd5038e-05f4-4bac-a5df-bb8c2ae2818b" />
如图，将原本评论卡片的头像和用户名跳转到文章页面改为跳转到个人主页，未登录者不变，设置过个人资料中网站的登录用户不变。

默认说说分类功能有助于外观>自定义>菜单>添加项目>说说>全部说说页面的自动分类