### PR TITLE
修复错误的引号使用和拼写错误

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -215,17 +215,17 @@ function get_smilies_panel() {
                 )):[]) // 用户登录则不显示任何字段
             );
 
-			function comment_cookies_check_lable($field) {
+			function comment_cookies_check_label($field) {
 				$field = '
 							<label class="siren-checkbox-label">
-								<input class="siren-checkbox-radio id="wp-comment-cookies-consent" name="wp-comment-cookies-consent" type="checkbox" value="yes">
+								<input class="siren-checkbox-radio" id="wp-comment-cookies-consent" name="wp-comment-cookies-consent" type="checkbox" value="yes">
 								<span class="siren-mail-notify-checkbox siren-checkbox-radioInput"></span>
 								' . __('Save your private info', 'sakurairo') . '
 							</label></div>
 						 ';
 				return $field;
 			}
-			add_filter('comment_form_field_cookies', 'comment_cookies_check_lable');
+			add_filter('comment_form_field_cookies', 'comment_cookies_check_label');
 
             comment_form($args);
         }


### PR DESCRIPTION
## 问题描述
10个月前提交 92fe70e38c79c1f340fefe47714b737cb3288c15 添加的评论cookie同意功能中，HTML属性引号使用有误，导致JavaScript无法通过id获取元素。

## 修复内容
- 修正拼写错误，从`comment_cookies_check_lable`改为`comment_cookies_check_label`
- 修正 `comment_cookies_check_label` 函数中的HTML属性引号
- 从 `class="siren-checkbox-radio id="wp-comment-cookies-consent"` 改为 `class="siren-checkbox-radio" id="wp-comment-cookies-consent"`
- 保持原有的div闭合结构不变

## 影响
- JavaScript现在可以正常通过 `getElementById('wp-comment-cookies-consent')` 获取复选框元素
- 保存个人信息到cookie的功能可以正常使用
- 向后兼容，不影响现有功能