### PR TITLE
feat: add toggle to hide splash wallpaper

### DIFF
--- a/header.php
+++ b/header.php
@@ -211,7 +211,7 @@ header('X-Frame-Options: SAMEORIGIN');
 
         // Cache commonly used options
         $show_user_avatar = (bool)iro_opt('nav_user_menu',true);
-        $enable_random_graphs = (bool)iro_opt('cover_switch', true) && (bool)iro_opt('cover_random_graphs_switch', true);
+        $enable_random_graphs = (bool)iro_opt('cover_switch', true) && (bool)iro_opt('cover_random_graphs_switch', true) && !(bool)iro_opt('hide_splash_wallpaper_switch');
         ?>
 
         <!-- Navigation and Search Section -->
@@ -271,7 +271,7 @@ header('X-Frame-Options: SAMEORIGIN');
      
     <section id="main-container">
         <?php
-        if (iro_opt('cover_switch')) {
+        if (iro_opt('cover_switch') && (!is_home() || !iro_opt('hide_splash_wallpaper_switch'))) {
             $filter = iro_opt('random_graphs_filter');
             $cover_height = (iro_opt('cover_full_screen',true)&&is_home()) ? '' : 'headertop-bar';
         ?>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -620,6 +620,21 @@ $sections = [
 					]
 				],
 			],
+			[
+				'type'     => 'switch',
+				'settings' => 'hide_splash_wallpaper_switch',
+				'iro_key'  => 'hide_splash_wallpaper_switch',
+				'label'    => esc_html__( 'Hide Splash Wallpaper', 'Sakurairo_C' ),
+				'description' => esc_html__( 'If enabled, the splash wallpaper and related effects on the homepage will be hidden.', 'Sakurairo_C' ),
+				'default'  => false,
+				'active_callback' => [
+					[
+						'setting'  => 'cover_switch',
+						'operator' => '==',
+						'value'    => true,
+					]
+				],
+			],
 		],
     ],
 	// ====================封面信息栏====================

--- a/inc/decorate.php
+++ b/inc/decorate.php
@@ -68,6 +68,9 @@ $bg_style = iro_opt('cover_full_screen') ?'': 'background-position: center cente
 echo $bg_style;
 echo iro_opt('site_bg_as_cover',false)? 'background:#0000;':'';
  ?>}
+<?php if (iro_opt('hide_splash_wallpaper_switch')): ?>
+#centerbg, #banner_wave_1, #banner_wave_2 { display: none !important; }
+<?php endif; ?>
 
 /*预加载部分*/
 

--- a/inc/swicher.php
+++ b/inc/swicher.php
@@ -24,7 +24,7 @@ function font_end_js_control()
     };
 
     $vision_resource_basepath = iro_opt('vision_resource_basepath', 'https://s.nmxc.ltd/sakurairo_vision/@3.0/');
-    $movies = iro_opt('cover_video') ?
+    $movies = (iro_opt('cover_video') && !iro_opt('hide_splash_wallpaper_switch')) ?
         array(
             'url' => iro_opt('cover_video_link'),
             'name' => iro_opt('cover_video_title'),
@@ -41,6 +41,7 @@ function font_end_js_control()
     $lightbox = iro_opt('lightbox');
     $annotations = get_post_meta(get_the_ID(), 'iro_chatgpt_annotations', true);
     $reception_background = iro_opt('reception_background');
+    $hide_splash = check(iro_opt('hide_splash_wallpaper_switch'));
     $iro_opt = [
         // Poi
         'pjax' => check(iro_opt('poi_pjax')),
@@ -59,12 +60,13 @@ function font_end_js_control()
         'gravatar_url' => $gravatar_url,
         // options
         'NProgressON' => check(iro_opt('nprogress_on')),
+        'hide_splash_wallpaper_switch' => $hide_splash,
         'baguetteBox' => check($lightbox === 'baguetteBox'),
         'fancybox' => check($lightbox === 'fancybox'),
         'darkmode' => check(iro_opt('theme_darkmode_auto')),
         'email_domain' => iro_opt('email_domain', ''),
         'email_name' => iro_opt('email_name', ''),
-        'extract_theme_skin' => iro_opt('extract_theme_skin_from_cover', false)?true:false,
+        'extract_theme_skin' => !$hide_splash && iro_opt('extract_theme_skin_from_cover', false) ? true : false,
         'ext_shared_lib' => iro_opt('external_vendor_lib'),
         'cookie_version_control' => iro_opt('cookie_version', ''),
         'qzone_autocomplete' => false,
@@ -87,8 +89,8 @@ function font_end_js_control()
         'theme_mathjax' => check(iro_opt('enable_theme_mathjax', true)),
         'comment_upload_img' => iro_opt('img_upload_api') == 'off' ? false : true,
         'img_upload_max_size' => iro_opt('img_upload_max_size',5),
-        'cache_cover' => check(iro_opt('cache_cover')),
-        'site_bg_as_cover' => check(iro_opt('site_bg_as_cover')),
+        'cache_cover' => !$hide_splash && check(iro_opt('cache_cover')),
+        'site_bg_as_cover' => !$hide_splash && check(iro_opt('site_bg_as_cover')),
         'yiyan_api' => empty(iro_opt('yiyan_api')) ? ["https://v1.hitokoto.cn/", "https://api.nmxc.ltd/yiyan/"] : json_decode(iro_opt('yiyan_api')),
         'skin_bg0' => $reception_background['img1'] ?? '',
         'skin_bg1' => $reception_background['img2'] ?? '',
@@ -101,19 +103,23 @@ function font_end_js_control()
         'is_admin' => check(current_user_can('manage_options')),
     ];
     // 判空 empty 如果变量不存在也会返回true
-    if (iro_opt('random_graphs_options') == 'external_api') {
-        //封面随机图api
-        if (wp_is_mobile()) {
-            $iro_opt['cover_api'] = iro_opt('random_graphs_mts') ? iro_opt('random_graphs_link_mobile') : iro_opt('random_graphs_link');
+    if (!iro_opt('hide_splash_wallpaper_switch')) {
+        if (iro_opt('random_graphs_options') == 'external_api') {
+            //封面随机图api
+            if (wp_is_mobile()) {
+                $iro_opt['cover_api'] = iro_opt('random_graphs_mts') ? iro_opt('random_graphs_link_mobile') : iro_opt('random_graphs_link');
+            } else {
+                $iro_opt['cover_api'] = iro_opt('random_graphs_link');
+            }
         } else {
-            $iro_opt['cover_api'] = iro_opt('random_graphs_link');
+            if (wp_is_mobile()) {
+                $iro_opt['cover_api'] = rest_url('sakura/v1/gallery') . '?img=l';
+            } else {
+                $iro_opt['cover_api'] = rest_url('sakura/v1/gallery') . '?img=w';
+            }
         }
     } else {
-        if (wp_is_mobile()) {
-            $iro_opt['cover_api'] = rest_url('sakura/v1/gallery') . '?img=l';
-        } else {
-            $iro_opt['cover_api'] = rest_url('sakura/v1/gallery') . '?img=w';
-        }
+        $iro_opt['cover_api'] = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
     }
     if ($lightbox === 'lightgallery') {
         # 请务必使用正确标准的json格式

--- a/layouts/imgbox.php
+++ b/layouts/imgbox.php
@@ -311,6 +311,7 @@ $print_social_zone = function() use ($all_opt): void {
 }
 ?>
 
+<?php if (!iro_opt('hide_splash_wallpaper_switch')) : ?>
 <div id="banner_wave_1"></div>
 <div id="banner_wave_2"></div>
 <figure id="centerbg" class="centerbg" style="<?php echo iro_opt('cover_full_screen',true) ? "height: 100vh;" : ''; ?>">
@@ -351,10 +352,13 @@ $print_social_zone = function() use ($all_opt): void {
         </div>
     <?php } ?>
 </figure>
+<?php endif; ?>
 <?php
-echo bgvideo();
+if (!iro_opt('hide_splash_wallpaper_switch')) {
+    echo bgvideo();
+}
 ?>
 <!-- 首页下拉箭头 -->
-<?php if (iro_opt('drop_down_arrow', 'true')) : ?>
+<?php if (iro_opt('drop_down_arrow', 'true') && !iro_opt('hide_splash_wallpaper_switch')) : ?>
 <div class="headertop-down" onclick="headertop_down()"><span><svg t="1682342753354" class="homepage-downicon" viewBox="0 0 1843 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="21355" width="80px" height="80px"><path d="M1221.06136021 284.43250057a100.69380037 100.69380037 0 0 1 130.90169466 153.0543795l-352.4275638 302.08090944a100.69380037 100.69380037 0 0 1-130.90169467 0L516.20574044 437.48688007A100.69380037 100.69380037 0 0 1 647.10792676 284.43250057L934.08439763 530.52766665l286.97696258-246.09516608z" fill="<?php echo iro_opt('drop_down_arrow_color'); ?>" p-id="21356"></path></svg></span></div>
 <?php endif; ?>

--- a/layouts/sakura_header.php
+++ b/layouts/sakura_header.php
@@ -118,7 +118,7 @@ $show_user_avatar = (bool)iro_opt('nav_user_menu',true);
     <?php } ?>
 
     <?php
-    if (iro_opt('cover_switch', true) == true && iro_opt('cover_random_graphs_switch', true) == true): ?>
+    if (iro_opt('cover_switch', true) == true && iro_opt('cover_random_graphs_switch', true) == true && !iro_opt('hide_splash_wallpaper_switch')): ?>
       <div class="bg-switch" id="bg-next">
         <i class="fa-solid fa-dice" aria-hidden="true"></i>
         <span class="screen-reader-text">


### PR DESCRIPTION
## Summary
- add Customizer toggle to hide splash screen wallpaper (default: off)
- wire option through switcher and template rendering path
- hide splash-related elements when enabled
- prevent splash background output/request path when enabled

## Files changed
- header.php
- inc/customizer.php
- inc/decorate.php
- inc/swicher.php
- layouts/imgbox.php
- layouts/sakura_header.php

## Verification
- toggle off: behavior unchanged
- toggle on: splash wallpaper elements hidden and background output path blocked

Closes local task for "hide splash wallpaper" with minimal invasive changes.
