### PR TITLE
修复胶囊统计缓存不会随文章/友情链接变更及时刷新

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4221,14 +4221,35 @@ function sakurairo_record_admin_login() {
 add_action('wp_loaded', 'sakurairo_record_admin_login');
 
 // 添加钩子，在发布/更新文章或者评论时刷新缓存
-function sakurairo_refresh_stats_on_action() {
-    if (current_user_can('edit_post')) {
-        delete_transient('sakurairo_site_stats');
+function sakurairo_refresh_stats_on_action($post_id = 0, $post = null, $update = false) {
+    // 针对文章相关 hook，避免 autosave / revision / auto-draft 造成无意义刷新
+    if (!empty($post_id)) {
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+            return;
+        }
+
+        if (wp_is_post_revision($post_id)) {
+            return;
+        }
+
+        if (get_post_status($post_id) === 'auto-draft') {
+            return;
+        }
     }
+
+    delete_transient('sakurairo_site_stats');
 }
-add_action('wp_insert_post', 'sakurairo_refresh_stats_on_action');
-add_action('edit_post', 'sakurairo_refresh_stats_on_action');
+
+/* 文章变更时刷新胶囊统计缓存 */
+add_action('save_post', 'sakurairo_refresh_stats_on_action', 10, 3);
+add_action('deleted_post', 'sakurairo_refresh_stats_on_action');
+add_action('trash_post', 'sakurairo_refresh_stats_on_action');
+
+/* 评论变更时刷新胶囊统计缓存 */
 add_action('wp_insert_comment', 'sakurairo_refresh_stats_on_action');
+add_action('edit_comment', 'sakurairo_refresh_stats_on_action');
+add_action('deleted_comment', 'sakurairo_refresh_stats_on_action');
+
 /* 友链变更时清理胶囊统计缓存 */
 add_action('added_link', 'sakurairo_refresh_stats_on_action');
 add_action('edit_link', 'sakurairo_refresh_stats_on_action');

--- a/functions.php
+++ b/functions.php
@@ -4220,28 +4220,39 @@ function sakurairo_record_admin_login() {
 }
 add_action('wp_loaded', 'sakurairo_record_admin_login');
 
-// 添加钩子，在发布/更新文章或者评论时刷新缓存
-function sakurairo_refresh_stats_on_action($post_id = 0, $post = null, $update = false) {
-    // 针对文章相关 hook，避免 autosave / revision / auto-draft 造成无意义刷新
-    if (!empty($post_id)) {
-        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
-            return;
-        }
+function sakurairo_refresh_stats_on_action(...$args) {
+    delete_transient('sakurairo_site_stats');
+}
 
-        if (wp_is_post_revision($post_id)) {
-            return;
-        }
+/**
+ * 文章保存时：清理胶囊统计缓存
+ * 仅供 save_post 使用，避免 autosave / revision / auto-draft 造成无意义刷新
+ */
+function sakurairo_refresh_stats_on_post_action($post_id, $post = null, $update = false) {
+    if (empty($post_id)) {
+        return;
+    }
 
-        if (get_post_status($post_id) === 'auto-draft') {
-            return;
-        }
+    // 自动保存不处理
+    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        return;
+    }
+
+    // autosave / revision 不处理
+    if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id)) {
+        return;
+    }
+
+    // 自动草稿不处理
+    if (get_post_status($post_id) === 'auto-draft') {
+        return;
     }
 
     delete_transient('sakurairo_site_stats');
 }
 
 /* 文章变更时刷新胶囊统计缓存 */
-add_action('save_post', 'sakurairo_refresh_stats_on_action', 10, 3);
+add_action('save_post', 'sakurairo_refresh_stats_on_post_action', 10, 3);
 add_action('deleted_post', 'sakurairo_refresh_stats_on_action');
 add_action('trash_post', 'sakurairo_refresh_stats_on_action');
 
@@ -4250,7 +4261,7 @@ add_action('wp_insert_comment', 'sakurairo_refresh_stats_on_action');
 add_action('edit_comment', 'sakurairo_refresh_stats_on_action');
 add_action('deleted_comment', 'sakurairo_refresh_stats_on_action');
 
-/* 友链变更时清理胶囊统计缓存 */
+/* 友情链接变更时刷新胶囊统计缓存 */
 add_action('added_link', 'sakurairo_refresh_stats_on_action');
 add_action('edit_link', 'sakurairo_refresh_stats_on_action');
 add_action('delete_link', 'sakurairo_refresh_stats_on_action');

--- a/functions.php
+++ b/functions.php
@@ -4229,6 +4229,10 @@ function sakurairo_refresh_stats_on_action() {
 add_action('wp_insert_post', 'sakurairo_refresh_stats_on_action');
 add_action('edit_post', 'sakurairo_refresh_stats_on_action');
 add_action('wp_insert_comment', 'sakurairo_refresh_stats_on_action');
+/* 友链变更时清理胶囊统计缓存 */
+add_action('added_link', 'sakurairo_refresh_stats_on_action');
+add_action('edit_link', 'sakurairo_refresh_stats_on_action');
+add_action('delete_link', 'sakurairo_refresh_stats_on_action');
 
 // 格式化时间差函数 - 将分钟转换为友好的文本格式
 function format_time_diff($minutes) {


### PR DESCRIPTION
Closes #1389

### 概述
完善 `sakurairo_site_stats` 的缓存失效逻辑，使首页胶囊统计在友情链接、文章、评论内容发生变化后能够及时刷新。

### 改动
本次修改位于 `functions.php`，围绕现有缓存清理逻辑及其 `add_action(...)` 注册位置进行调整，主要包含以下几部分：

#### 1. 友情链接相关
补充以下 hook：

- `added_link`
- `edit_link`
- `delete_link`

这样在新增、编辑、删除友情链接后，会及时清理 `sakurairo_site_stats`，避免首页胶囊中的友链数量、随机友链继续显示旧数据。

#### 2. 文章相关
补充以下 hook：

- `save_post`
- `deleted_post`
- `trash_post`

用于覆盖文章保存、删除、移入回收站等会影响胶囊统计的场景。

其中：

- `save_post` 使用 `sakurairo_refresh_stats_on_post_action`处理
- `deleted_post`、`trash_post` 使用原本的 `sakurairo_refresh_stats_on_action`处理

#### 3. 评论相关
继续保留评论相关缓存清理逻辑：

- `wp_insert_comment`
- `edit_comment`
- `deleted_comment`