### PR TITLE
修复友链分类未设置 term_priority 时不显示的问题

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -904,20 +904,34 @@ function get_the_link_items($id = null)
 }
 
 function get_link_items() {
-    // 获取链接分类并按优先级降序排列
+    // 获取链接分类
     $linkcats = get_terms(array(
         'taxonomy'   => 'link_category',
-        'meta_key'   => 'term_priority', // 优先级字段
-        'orderby'    => 'meta_value_num', 
-        'order'      => 'DESC', 
-        'hide_empty' => false
+        'hide_empty' => false,  // 可按需改为 true，隐藏空分类
     ));
 
-    // 检查是否返回错误或空结果
+    // 先检查错误，再排序
     if (is_wp_error($linkcats) || empty($linkcats)) {
         return get_the_link_items(); // 友链无分类或出错，直接返回全部列表  
     }
-    
+
+    // 按 term_priority 排序，未设置的排最后
+    usort($linkcats, function($a, $b) {
+        $pa = get_term_meta($a->term_id, 'term_priority', true);
+        $pb = get_term_meta($b->term_id, 'term_priority', true);
+        
+        // 都没设置，按名称排序
+        if ($pa === '' && $pb === '') {
+            return strcmp($a->name, $b->name);
+        }
+        // 没设置的放最后
+        if ($pa === '') return 1;
+        if ($pb === '') return -1;
+        
+        // 降序：数字大的在前
+        return intval($pb) - intval($pa);
+    });
+
     $result = '';
     $pending_cat_name = __('Pending Links', 'sakurairo'); // 未审核链接分类名称
     


### PR DESCRIPTION
## 问题描述

当前 `get_link_items()` 函数在获取链接分类时，使用了 `meta_key => 'term_priority'` 参数：

```php
$linkcats = get_terms(array(
    'taxonomy' => 'link_category',
    'meta_key' => 'term_priority',
    'orderby'  => 'meta_value_num',
    'order'    => 'DESC'
));
```
这导致 所有未设置 term_priority 元数据的链接分类都会被过滤掉，其下的友链无法按分类分组显示，而是全部混在一起平铺输出（或完全不显示）。
## 复现步骤
进入后台「链接 → 链接分类」，新建一个分类（不设置优先级）
添加若干链接并分配到该分类
创建页面并选择「友情链接模板」
前台查看友链页面，发现该分类下的链接没有按组显示
## 预期行为
即使没有设置 term_priority，链接分类也应该正常显示，并按名称或其他合理顺序排列。
## 实际行为
未设置 term_priority 的分类被 get_terms() 过滤，分类下的链接无法分组展示。
## 解决方案
### 临时解决方案
在数据库中执行sql语句，将缺失的分类映射添加回来
执行以下 SQL，为对应分类ID（在wp_terms表中找到term_id；或者可以在后台链接分类列表的 URL 中看到 tag_ID=xxx）添加优先级（term_priority）（数字越大越靠前）：
```sql
INSERT INTO wp_termmeta (term_id, meta_key, meta_value) VALUES (分类ID, 'term_priority', 10);
```
### 代码解决方案
移除 get_terms() 中的 meta_key 限制，改为获取所有 link_category 分类，然后在 PHP 层面通过 usort() 实现优先级排序：
有 term_priority 的分类：继续按数字大小降序排列（数字越大越靠前），保持原有行为
没有 term_priority 的分类：也能正常显示，默认排在有优先级的分类之后；若都没有设置，则按分类名称升序排列
## 向后兼容性
✅ 完全兼容：已有 term_priority 的分类排序逻辑不变，只是额外支持了未设置优先级的分类。

AI声明：此问题原因排查、解决方案均有AI参与