### PR TITLE
fix: 修复 get_author_class SQL 注入漏洞

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -756,9 +756,12 @@ if (!function_exists('akina_comment_format')) {
 function get_author_class($comment_author_email, $user_id)
 {
     global $wpdb;
-    $author_count = count(
-        $wpdb->get_results(
-            "SELECT comment_ID as author_count FROM $wpdb->comments WHERE comment_author_email = '$comment_author_email' "
+    // 安全修复：用 prepare 参数化查询防止 SQL 注入
+    // 性能优化：用 COUNT(*) + get_var 替代 get_results + count（语义完全等价）
+    $author_count = (int) $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_author_email = %s",
+            $comment_author_email
         )
     );
     # 等级梯度


### PR DESCRIPTION
## 问题
`get_author_class()` 函数将 `$comment_author_email` 直接拼接进 SQL 查询字符串，未使用预处理语句。攻击者可通过评论作者邮箱字段注入任意 SQL，导致数据泄露或篡改。

## 修复
**1. `$wpdb->prepare()` 参数化**（安全修复）
- 正常邮箱：查询结果完全相同
- 异常输入：原代码 SQL 错误返回 0，改进后安全转义查询，不构成"影响原有功能"

**2. `COUNT(*)` + `get_var` 替代 `get_results` + `count`**（性能优化）
- 原查询无 `LIMIT`/`GROUP BY`/`HAVING`，两者语义完全等价
- 边界场景全部一致：匹配 N 条→N、无匹配→0、DB 错误→0
- `(int)null === 0` 与 `count([]) === 0` 一致

## 差异
有一个可能的细微差异：如果恶意字符串恰好是数据库中某个 `comment_author_email` 的值（极不可能），改进版会返回非 0。但这种情况概率极低，且原代码会因为 SQL 语法错误返回 0。

## 建议
**N+1 查询问题**：`get_author_class()` 在评论列表循环中每条评论触发一次查询。建议 "Avoid N+1 query patterns"。或可考虑用 object cache 批量预取所有评论作者的计数。

## 兼容
- 所有方法符合主题最低要求 WP 6.0，PHP8.0