### PR TITLE
fix(chatgpt): handle truncated annotation responses

### DIFF
--- a/inc/chatgpt/aigc-manage.php
+++ b/inc/chatgpt/aigc-manage.php
@@ -217,10 +217,10 @@ function render_annotations_admin_page() {
                 echo '<p><strong>' . __('Number of Annotations:', 'sakurairo') . '</strong> ' . count($annotations) . '</p>';
                 echo '<p><strong>' . __('Annotation Data:', 'sakurairo') . '</strong></p>';
                 echo '<pre style="background:#f5f5f5; padding:10px; max-height:300px; overflow:auto;">';
-                print_r($annotations);
+                echo esc_html(print_r($annotations, true));
                 echo '</pre>';
             } else {
-                echo '<p><strong>' . __('Annotation Data:', 'sakurairo') . '</strong> ' . var_export($annotations, true) . '</p>';
+                echo '<p><strong>' . __('Annotation Data:', 'sakurairo') . '</strong> ' . esc_html(var_export($annotations, true)) . '</p>';
             }
             
             // 检查数据库记录
@@ -274,20 +274,47 @@ function render_annotations_admin_page() {
         
         <script>
         document.addEventListener('DOMContentLoaded', function() {
+            const deleteLabel = <?php echo wp_json_encode(__('Delete', 'sakurairo')); ?>;
+
+            function createAnnotationRow(term = '', explanation = '') {
+                const row = document.createElement('tr');
+                const termCell = document.createElement('td');
+                const explanationCell = document.createElement('td');
+                const actionCell = document.createElement('td');
+                const termInput = document.createElement('input');
+                const explanationInput = document.createElement('textarea');
+                const deleteButton = document.createElement('button');
+
+                termInput.type = 'text';
+                termInput.name = 'term[]';
+                termInput.value = term;
+                explanationInput.name = 'explanation[]';
+                explanationInput.value = explanation;
+                deleteButton.type = 'button';
+                deleteButton.className = 'delete-row';
+                deleteButton.textContent = deleteLabel;
+
+                termCell.appendChild(termInput);
+                explanationCell.appendChild(explanationInput);
+                actionCell.appendChild(deleteButton);
+                row.append(termCell, explanationCell, actionCell);
+
+                return row;
+            }
+
             // 用于展示编辑表单的函数
             function displayAnnotations(title, annotations, postId) {
-                document.getElementById('modal-title').textContent = <?php echo json_encode(__('Post Annotations: ', 'sakurairo')); ?> + title;
+                document.getElementById('modal-title').textContent = <?php echo wp_json_encode(__('Post Annotations: ', 'sakurairo')); ?> + title;
                 document.getElementById('current-post-id').value = postId;
-                let tbody = document.querySelector('#annotations-table tbody');
-                tbody.innerHTML = ''; // 清空原有内容
+                const tbody = document.querySelector('#annotations-table tbody');
+                tbody.replaceChildren();
                 
                 // 根据已有注释渲染行
-                for (const term in annotations) {
-                    let tr = document.createElement('tr');
-                    tr.innerHTML = `<td><input type="text" name="term[]" value="${term}" /></td>
-                                    <td><textarea name="explanation[]">${annotations[term]}</textarea></td>
-                                    <td><button type="button" class="delete-row"><?php echo __('Delete', 'sakurairo'); ?></button></td>`;
-                    tbody.appendChild(tr);
+                for (const [term, explanation] of Object.entries(annotations)) {
+                    if (typeof explanation !== 'string') {
+                        continue;
+                    }
+                    tbody.appendChild(createAnnotationRow(term, explanation));
                 }
                 document.getElementById('annotation-modal').style.display = 'block';
             }
@@ -317,12 +344,8 @@ function render_annotations_admin_page() {
 
             // 添加新行
             document.getElementById('add-annotation').addEventListener('click', function() {
-                let tbody = document.querySelector('#annotations-table tbody');
-                let tr = document.createElement('tr');
-                tr.innerHTML = `<td><input type="text" name="term[]" value="" /></td>
-                                <td><textarea name="explanation[]"></textarea></td>
-                                <td><button type="button" class="delete-row"><?php echo __('Delete', 'sakurairo'); ?></button></td>`;
-                tbody.appendChild(tr);
+                const tbody = document.querySelector('#annotations-table tbody');
+                tbody.appendChild(createAnnotationRow());
             });
 
             // 删除
@@ -340,7 +363,7 @@ function render_annotations_admin_page() {
                 const explanations = Array.from(document.querySelectorAll('textarea[name="explanation[]"]')).map(textarea => textarea.value.trim());
                 
                 // 组装数据
-                let annotations = {};
+                const annotations = Object.create(null);
                 for (let i = 0; i < terms.length; i++) {
                     if (terms[i] !== '') {  // 排除空内容
                         annotations[terms[i]] = explanations[i];
@@ -436,18 +459,12 @@ function generate_annotations_for_post($post_id) {
     error_log("IROChatGPT: 开始为文章 {$post_id} 生成注释");
     $annotations = call_chatgpt_for_annotations($content);
     
-    if (empty($annotations) || !is_array($annotations)) {
+    if (empty($annotations) || !is_string_annotation_map($annotations)) {
         error_log("IROChatGPT: API返回无效数据，未能生成注释");
         return false;
     }
     
     error_log("IROChatGPT: 成功获取注释数据，准备保存。注释数量: " . count($annotations));
-    
-    // 保存前先验证注释是否有效
-    if (!is_array($annotations)) {
-        error_log("IROChatGPT: 注释数据不是数组格式");
-        return false;
-    }
     
     // 直接测试保存结果
     $save_result = update_post_meta($post_id, 'iro_chatgpt_annotations', $annotations);
@@ -484,11 +501,14 @@ function ajax_get_post_annotations() {
     if (!$post) {
         wp_send_json_error(__('Post not found', 'sakurairo'));
     }
+
+    if (!current_user_can('edit_post', $post_id)) {
+        wp_send_json_error(__('Access denied', 'sakurairo'), 403);
+    }
     
     $annotations = get_post_meta($post_id, 'iro_chatgpt_annotations', true);
-    error_log("IROChatGPT: 从文章 {$post_id} 获取注释数据: " . print_r($annotations, true));
     
-    if (empty($annotations)) {
+    if (empty($annotations) || !is_string_annotation_map($annotations)) {
         wp_send_json_error(__('This post does not have any annotation data', 'sakurairo'));
     }
     
@@ -518,7 +538,7 @@ function ajax_update_post_annotations() {
     
     // 获取并解析注释数据
     $annotations = isset($_POST['annotations']) ? json_decode(stripslashes($_POST['annotations']), true) : null;
-    if (!is_array($annotations)) {
+    if (!is_string_annotation_map($annotations)) {
         wp_send_json_error(__('Invalid annotations data', 'sakurairo'));
     }
     

--- a/inc/chatgpt/annotation-response.php
+++ b/inc/chatgpt/annotation-response.php
@@ -1,0 +1,377 @@
+<?php
+
+namespace IROChatGPT {
+
+    const ANNOTATION_OUTPUT_TOKEN_LIMIT = 4096;
+    const ANNOTATION_MAX_RETRY_ATTEMPTS = 1;
+    const ANNOTATION_RETRY_PARTS = 2;
+
+    function annotation_response_failure($error_code, $error_message, $finish_reason = null)
+    {
+        $error_message = preg_replace('/\s+/', ' ', (string) $error_message);
+
+        return [
+            'annotations' => [],
+            'error_code' => $error_code,
+            'error_message' => substr($error_message, 0, 200),
+            'finish_reason' => $finish_reason,
+        ];
+    }
+
+    function is_string_annotation_map($annotations)
+    {
+        if (!is_array($annotations)) {
+            return false;
+        }
+
+        foreach ($annotations as $term => $explanation) {
+            if (!is_string($term) || !is_string($explanation)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Combine parsed segment responses atomically.
+     */
+    function combine_annotation_response_results($response_results)
+    {
+        $annotations = [];
+
+        foreach ($response_results as $index => $response_result) {
+            if (
+                !is_array($response_result)
+                || !array_key_exists('error_code', $response_result)
+                || $response_result['error_code'] !== null
+                || !array_key_exists('annotations', $response_result)
+                || !is_string_annotation_map($response_result['annotations'])
+            ) {
+                return [
+                    'annotations' => [],
+                    'error_code' => 'segment_failure',
+                    'failed_segment' => $index,
+                ];
+            }
+
+            $annotations = array_merge($annotations, $response_result['annotations']);
+        }
+
+        return [
+            'annotations' => $annotations,
+            'error_code' => null,
+            'failed_segment' => null,
+        ];
+    }
+
+    /**
+     * Split one truncated input into exactly two smaller UTF-8-safe segments.
+     */
+    function split_annotation_segment_for_retry($segment)
+    {
+        $segment = trim((string) $segment);
+        if ($segment === '') {
+            return [];
+        }
+
+        $paragraphs = preg_split('/\n\s*\n/u', $segment, -1, PREG_SPLIT_NO_EMPTY);
+        if (is_array($paragraphs) && count($paragraphs) > 1) {
+            $target_length = strlen($segment) / ANNOTATION_RETRY_PARTS;
+            $left = [];
+            $right = $paragraphs;
+            $left_length = 0;
+
+            while (count($right) > 1) {
+                $next = $right[0];
+                if (!empty($left) && $left_length + strlen($next) > $target_length) {
+                    break;
+                }
+
+                $left[] = array_shift($right);
+                $left_length += strlen($next) + 2;
+            }
+
+            $parts = [
+                trim(implode("\n\n", $left)),
+                trim(implode("\n\n", $right)),
+            ];
+        } else {
+            $characters = preg_split('//u', $segment, -1, PREG_SPLIT_NO_EMPTY);
+            if (!is_array($characters) || count($characters) < ANNOTATION_RETRY_PARTS) {
+                return [];
+            }
+
+            $character_count = count($characters);
+            $midpoint = (int) ceil($character_count / ANNOTATION_RETRY_PARTS);
+            $search_radius = (int) floor($character_count / 4);
+
+            for ($offset = 0; $offset <= $search_radius; $offset++) {
+                foreach ([$midpoint + $offset, $midpoint - $offset] as $candidate) {
+                    if ($candidate <= 0 || $candidate >= $character_count) {
+                        continue;
+                    }
+
+                    if (preg_match('/[\s。！？.!?；;,，]/u', $characters[$candidate - 1]) === 1) {
+                        $midpoint = $candidate;
+                        break 2;
+                    }
+                }
+            }
+
+            $parts = [
+                implode('', array_slice($characters, 0, $midpoint)),
+                implode('', array_slice($characters, $midpoint)),
+            ];
+        }
+
+        if (count($parts) !== ANNOTATION_RETRY_PARTS || in_array('', $parts, true)) {
+            return [];
+        }
+
+        return $parts;
+    }
+
+    /**
+     * Plan one bounded retry only for token-limit failures.
+     */
+    function build_annotation_retry_plan($segments, $response_results)
+    {
+        $retry_segments = [];
+
+        foreach ($segments as $index => $segment) {
+            if (!isset($response_results[$index]) || !is_array($response_results[$index])) {
+                return [
+                    'retry_segments' => [],
+                    'error_code' => 'response_missing',
+                    'failed_segment' => $index,
+                ];
+            }
+
+            $error_code = array_key_exists('error_code', $response_results[$index])
+                ? $response_results[$index]['error_code']
+                : 'response_invalid';
+            if ($error_code === null) {
+                continue;
+            }
+
+            if ($error_code !== 'model_output_truncated') {
+                return [
+                    'retry_segments' => [],
+                    'error_code' => 'non_retryable_failure',
+                    'failed_segment' => $index,
+                ];
+            }
+
+            $parts = split_annotation_segment_for_retry($segment);
+            if (count($parts) !== ANNOTATION_RETRY_PARTS) {
+                return [
+                    'retry_segments' => [],
+                    'error_code' => 'retry_split_failed',
+                    'failed_segment' => $index,
+                ];
+            }
+
+            $retry_segments[$index] = $parts;
+        }
+
+        return [
+            'retry_segments' => $retry_segments,
+            'error_code' => null,
+            'failed_segment' => null,
+        ];
+    }
+
+    /**
+     * Replace truncated initial responses with one successful retry result each.
+     */
+    function apply_annotation_retry_results($initial_results, $retry_results)
+    {
+        foreach ($initial_results as $index => $initial_result) {
+            $error_code = is_array($initial_result) && array_key_exists('error_code', $initial_result)
+                ? $initial_result['error_code']
+                : 'response_invalid';
+
+            if ($error_code === null) {
+                continue;
+            }
+
+            if ($error_code !== 'model_output_truncated' || !isset($retry_results[$index])) {
+                return [
+                    'response_results' => $initial_results,
+                    'error_code' => 'retry_failed',
+                    'failed_segment' => $index,
+                ];
+            }
+
+            $combined_retry = combine_annotation_response_results($retry_results[$index]);
+            if ($combined_retry['error_code'] !== null) {
+                return [
+                    'response_results' => $initial_results,
+                    'error_code' => 'retry_failed',
+                    'failed_segment' => $index,
+                ];
+            }
+
+            $initial_results[$index] = [
+                'annotations' => $combined_retry['annotations'],
+                'error_code' => null,
+                'error_message' => null,
+                'finish_reason' => 'stop',
+            ];
+        }
+
+        return [
+            'response_results' => $initial_results,
+            'error_code' => null,
+            'failed_segment' => null,
+        ];
+    }
+
+    /**
+     * Parse one OpenAI-compatible annotation response without WordPress dependencies.
+     */
+    function parse_annotation_response($response, $curl_errno = 0, $http_status = 200)
+    {
+        if ($curl_errno !== 0) {
+            return annotation_response_failure('curl_error', 'cURL request failed');
+        }
+
+        if ($http_status < 200 || $http_status >= 300) {
+            return annotation_response_failure(
+                'http_error',
+                sprintf('API returned HTTP status %d', $http_status)
+            );
+        }
+
+        if (!is_string($response) || trim($response) === '') {
+            return annotation_response_failure('empty_response', 'API returned an empty response');
+        }
+
+        $result = json_decode($response, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return annotation_response_failure(
+                'response_json_invalid',
+                'API response is not valid JSON: ' . json_last_error_msg()
+            );
+        }
+
+        if (!is_array($result)) {
+            return annotation_response_failure('response_json_invalid', 'API response is not a JSON object');
+        }
+
+        if (isset($result['error'])) {
+            return annotation_response_failure('model_error', 'Model API returned an error');
+        }
+
+        if (!isset($result['choices'][0]) || !is_array($result['choices'][0])) {
+            return annotation_response_failure('model_response_missing', 'Model response does not contain a choice');
+        }
+
+        $choice = $result['choices'][0];
+        $finish_reason = null;
+        if (array_key_exists('finish_reason', $choice) && $choice['finish_reason'] !== null) {
+            if (!is_string($choice['finish_reason'])) {
+                return annotation_response_failure(
+                    'model_finish_reason',
+                    'Model returned an invalid finish reason'
+                );
+            }
+
+            $finish_reason = $choice['finish_reason'];
+            $finish_reason = preg_replace('/\s+/', ' ', $finish_reason);
+            $finish_reason = substr($finish_reason, 0, 50);
+            if (!in_array($finish_reason, ['stop', 'length', 'content_filter', 'tool_calls', 'function_call'], true)) {
+                $finish_reason = 'other';
+            }
+        }
+
+        if ($finish_reason === 'length') {
+            return annotation_response_failure(
+                'model_output_truncated',
+                'Model output reached its token limit',
+                $finish_reason
+            );
+        }
+
+        if ($finish_reason !== null && $finish_reason !== 'stop') {
+            return annotation_response_failure(
+                'model_finish_reason',
+                'Model did not report a successful stop',
+                $finish_reason
+            );
+        }
+
+        if (
+            !isset($choice['message'])
+            || !is_array($choice['message'])
+            || !isset($choice['message']['content'])
+            || !is_string($choice['message']['content'])
+        ) {
+            return annotation_response_failure(
+                'model_response_missing',
+                'Model response does not contain message content',
+                $finish_reason
+            );
+        }
+
+        $annotation_json = trim($choice['message']['content']);
+        if (preg_match('/^```(?:json)?\s*(.*?)\s*```$/is', $annotation_json, $matches)) {
+            $annotation_json = trim($matches[1]);
+        }
+
+        if (
+            $annotation_json === ''
+            || substr($annotation_json, 0, 1) !== '{'
+            || substr($annotation_json, -1) !== '}'
+        ) {
+            $decoded_content = json_decode($annotation_json);
+            if (json_last_error() === JSON_ERROR_NONE && !is_object($decoded_content)) {
+                return annotation_response_failure(
+                    'annotation_schema_invalid',
+                    'Annotations must be a JSON object',
+                    $finish_reason
+                );
+            }
+
+            return annotation_response_failure(
+                'annotation_json_missing',
+                'Model content does not contain a complete JSON object',
+                $finish_reason
+            );
+        }
+
+        $annotation_object = json_decode($annotation_json);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return annotation_response_failure(
+                'annotation_json_invalid',
+                'Annotation JSON is invalid: ' . json_last_error_msg(),
+                $finish_reason
+            );
+        }
+
+        if (!is_object($annotation_object)) {
+            return annotation_response_failure(
+                'annotation_schema_invalid',
+                'Annotations must be a JSON object',
+                $finish_reason
+            );
+        }
+
+        $annotations = get_object_vars($annotation_object);
+        if (!is_string_annotation_map($annotations)) {
+            return annotation_response_failure(
+                'annotation_schema_invalid',
+                'Annotation terms and explanations must be strings',
+                $finish_reason
+            );
+        }
+
+        return [
+            'annotations' => $annotations,
+            'error_code' => null,
+            'error_message' => null,
+            'finish_reason' => $finish_reason,
+        ];
+    }
+}

--- a/inc/chatgpt/annotation-response.test.php
+++ b/inc/chatgpt/annotation-response.test.php
@@ -1,0 +1,343 @@
+<?php // phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit;
+}
+
+require_once __DIR__ . '/annotation-response.php';
+
+function annotation_api_response($content, $finish_reason = 'stop')
+{
+    return json_encode([
+        'choices' => [[
+            'finish_reason' => $finish_reason,
+            'message' => [
+                'content' => $content,
+            ],
+        ]],
+    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+}
+
+function assert_same($expected, $actual, $message = '')
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException(
+            ($message === '' ? '' : $message . ': ')
+            . 'expected ' . var_export($expected, true)
+            . ', got ' . var_export($actual, true)
+        );
+    }
+}
+
+$tests = [
+    'uses bounded output and retry limits' => function () {
+        assert_same(4096, \IROChatGPT\ANNOTATION_OUTPUT_TOKEN_LIMIT);
+        assert_same(1, \IROChatGPT\ANNOTATION_MAX_RETRY_ATTEMPTS);
+        assert_same(2, \IROChatGPT\ANNOTATION_RETRY_PARTS);
+    },
+    'parses a valid annotation object' => function () {
+        $result = \IROChatGPT\parse_annotation_response(
+            annotation_api_response('{"术语":"解释"}'),
+            0,
+            200
+        );
+
+        assert_same(null, $result['error_code']);
+        assert_same(['术语' => '解释'], $result['annotations']);
+        assert_same('stop', $result['finish_reason']);
+    },
+    'parses JSON inside a Markdown fence' => function () {
+        $content = "```json\n{\"term\":\"explanation\"}\n```";
+        $result = \IROChatGPT\parse_annotation_response(annotation_api_response($content));
+
+        assert_same(null, $result['error_code']);
+        assert_same(['term' => 'explanation'], $result['annotations']);
+    },
+    'accepts compatible responses without a finish reason' => function () {
+        $response = json_encode([
+            'choices' => [[
+                'message' => ['content' => '{"term":"explanation"}'],
+            ]],
+        ]);
+        $result = \IROChatGPT\parse_annotation_response($response);
+
+        assert_same(null, $result['error_code']);
+        assert_same(null, $result['finish_reason']);
+    },
+    'reports cURL failures without parsing a body' => function () {
+        $result = \IROChatGPT\parse_annotation_response('', 28, 0);
+
+        assert_same('curl_error', $result['error_code']);
+        assert_same([], $result['annotations']);
+        assert_same('cURL request failed', $result['error_message']);
+    },
+    'reports an empty successful response' => function () {
+        $result = \IROChatGPT\parse_annotation_response('', 0, 200);
+
+        assert_same('empty_response', $result['error_code']);
+        assert_same([], $result['annotations']);
+    },
+    'reports HTTP failures without exposing the response body' => function () {
+        $secret = 'sensitive-response-content';
+        $result = \IROChatGPT\parse_annotation_response($secret, 0, 429);
+
+        assert_same('http_error', $result['error_code']);
+        assert_same([], $result['annotations']);
+        assert_same(false, str_contains($result['error_message'], $secret));
+    },
+    'reports model API failures without exposing the response body' => function () {
+        $secret = 'sensitive-provider-message';
+        $response = json_encode(['error' => ['message' => $secret]]);
+        $result = \IROChatGPT\parse_annotation_response($response);
+
+        assert_same('model_error', $result['error_code']);
+        assert_same([], $result['annotations']);
+        assert_same(false, str_contains($result['error_message'], $secret));
+    },
+    'reports malformed outer JSON' => function () {
+        $result = \IROChatGPT\parse_annotation_response('{invalid');
+
+        assert_same('response_json_invalid', $result['error_code']);
+        assert_same([], $result['annotations']);
+    },
+    'reports a missing model choice' => function () {
+        $result = \IROChatGPT\parse_annotation_response('{"choices":[]}');
+
+        assert_same('model_response_missing', $result['error_code']);
+        assert_same([], $result['annotations']);
+    },
+    'reports missing model message content' => function () {
+        $response = json_encode([
+            'choices' => [[
+                'finish_reason' => 'stop',
+                'message' => [],
+            ]],
+        ]);
+        $result = \IROChatGPT\parse_annotation_response($response);
+
+        assert_same('model_response_missing', $result['error_code']);
+        assert_same([], $result['annotations']);
+        assert_same('stop', $result['finish_reason']);
+    },
+    'rejects output stopped by the token limit' => function () {
+        $response = annotation_api_response('{"term":"complete but truncated"}', 'length');
+        $result = \IROChatGPT\parse_annotation_response($response);
+
+        assert_same('model_output_truncated', $result['error_code']);
+        assert_same([], $result['annotations']);
+        assert_same('length', $result['finish_reason']);
+    },
+    'rejects other non-success finish reasons' => function () {
+        $response = annotation_api_response('{"term":"filtered"}', 'content_filter');
+        $result = \IROChatGPT\parse_annotation_response($response);
+
+        assert_same('model_finish_reason', $result['error_code']);
+        assert_same([], $result['annotations']);
+        assert_same('content_filter', $result['finish_reason']);
+    },
+    'rejects invalid finish reason types' => function () {
+        $response = json_encode([
+            'choices' => [[
+                'finish_reason' => ['unexpected'],
+                'message' => ['content' => '{"term":"explanation"}'],
+            ]],
+        ]);
+        $result = \IROChatGPT\parse_annotation_response($response);
+
+        assert_same('model_finish_reason', $result['error_code']);
+        assert_same([], $result['annotations']);
+        assert_same(null, $result['finish_reason']);
+    },
+    'redacts unknown finish reasons from diagnostics' => function () {
+        $secret = 'provider-secret-finish-reason';
+        $response = annotation_api_response('{"term":"explanation"}', $secret);
+        $result = \IROChatGPT\parse_annotation_response($response);
+
+        assert_same('model_finish_reason', $result['error_code']);
+        assert_same([], $result['annotations']);
+        assert_same('other', $result['finish_reason']);
+        assert_same(false, str_contains($result['error_message'], $secret));
+    },
+    'rejects truncated annotation JSON' => function () {
+        $result = \IROChatGPT\parse_annotation_response(
+            annotation_api_response('{"term":"truncated"')
+        );
+
+        assert_same('annotation_json_missing', $result['error_code']);
+        assert_same([], $result['annotations']);
+    },
+    'rejects malformed annotation JSON' => function () {
+        $result = \IROChatGPT\parse_annotation_response(
+            annotation_api_response('{"term": }')
+        );
+
+        assert_same('annotation_json_invalid', $result['error_code']);
+        assert_same([], $result['annotations']);
+    },
+    'rejects annotation values that are not strings' => function () {
+        $result = \IROChatGPT\parse_annotation_response(
+            annotation_api_response('{"term":{"nested":"value"}}')
+        );
+
+        assert_same('annotation_schema_invalid', $result['error_code']);
+        assert_same([], $result['annotations']);
+    },
+    'rejects annotation lists instead of extracting an inner object' => function () {
+        $result = \IROChatGPT\parse_annotation_response(
+            annotation_api_response('[{"term":"explanation"}]')
+        );
+
+        assert_same('annotation_schema_invalid', $result['error_code']);
+        assert_same([], $result['annotations']);
+    },
+    'rejects annotation keys that cannot remain strings' => function () {
+        $result = \IROChatGPT\parse_annotation_response(
+            annotation_api_response('{"1":"numeric term"}')
+        );
+
+        assert_same('annotation_schema_invalid', $result['error_code']);
+        assert_same([], $result['annotations']);
+    },
+    'combines successful segment responses' => function () {
+        $response_results = [
+            \IROChatGPT\parse_annotation_response(annotation_api_response('{"first":"valid"}')),
+            \IROChatGPT\parse_annotation_response(annotation_api_response('{"second":"also valid"}')),
+        ];
+        $combined = \IROChatGPT\combine_annotation_response_results($response_results);
+
+        assert_same(null, $combined['error_code']);
+        assert_same(['first' => 'valid', 'second' => 'also valid'], $combined['annotations']);
+        assert_same(null, $combined['failed_segment']);
+    },
+    'splits a truncated segment into two smaller paragraph groups' => function () {
+        $segment = "first paragraph\n\nsecond paragraph\n\nthird paragraph";
+        $parts = \IROChatGPT\split_annotation_segment_for_retry($segment);
+
+        assert_same(2, count($parts));
+        assert_same($segment, implode("\n\n", $parts));
+        assert_same(true, strlen($parts[0]) < strlen($segment));
+        assert_same(true, strlen($parts[1]) < strlen($segment));
+    },
+    'splits a single UTF-8 paragraph without corrupting characters' => function () {
+        $parts = \IROChatGPT\split_annotation_segment_for_retry('甲乙。丙丁戊');
+
+        assert_same(['甲乙。', '丙丁戊'], $parts);
+        assert_same('甲乙。丙丁戊', implode('', $parts));
+    },
+    'plans exactly two retry requests for each truncated segment' => function () {
+        $segments = [
+            "first half\n\nsecond half",
+            "third half\n\nfourth half",
+        ];
+        $truncated = \IROChatGPT\annotation_response_failure(
+            'model_output_truncated',
+            'Model output reached its token limit',
+            'length'
+        );
+        $plan = \IROChatGPT\build_annotation_retry_plan($segments, [$truncated, $truncated]);
+
+        assert_same(null, $plan['error_code']);
+        assert_same(2, count($plan['retry_segments']));
+        assert_same(2, count($plan['retry_segments'][0]));
+        assert_same(2, count($plan['retry_segments'][1]));
+    },
+    'does not retry non-token-limit failures' => function () {
+        $segments = ['first segment', 'second segment'];
+        $results = [
+            \IROChatGPT\parse_annotation_response(annotation_api_response('{"first":"valid"}')),
+            \IROChatGPT\annotation_response_failure('http_error', 'API returned HTTP status 500'),
+        ];
+        $plan = \IROChatGPT\build_annotation_retry_plan($segments, $results);
+
+        assert_same('non_retryable_failure', $plan['error_code']);
+        assert_same([], $plan['retry_segments']);
+        assert_same(1, $plan['failed_segment']);
+    },
+    'does not retry a segment that cannot be split safely' => function () {
+        $truncated = \IROChatGPT\annotation_response_failure(
+            'model_output_truncated',
+            'Model output reached its token limit',
+            'length'
+        );
+        $plan = \IROChatGPT\build_annotation_retry_plan(['甲'], [$truncated]);
+
+        assert_same('retry_split_failed', $plan['error_code']);
+        assert_same([], $plan['retry_segments']);
+        assert_same(0, $plan['failed_segment']);
+    },
+    'replaces one truncated response after both smaller retries succeed' => function () {
+        $truncated = \IROChatGPT\annotation_response_failure(
+            'model_output_truncated',
+            'Model output reached its token limit',
+            'length'
+        );
+        $initial_results = [
+            \IROChatGPT\parse_annotation_response(annotation_api_response('{"existing":"valid"}')),
+            $truncated,
+        ];
+        $retry_results = [1 => [
+            \IROChatGPT\parse_annotation_response(annotation_api_response('{"first":"valid"}')),
+            \IROChatGPT\parse_annotation_response(annotation_api_response('{"second":"also valid"}')),
+        ]];
+        $applied = \IROChatGPT\apply_annotation_retry_results($initial_results, $retry_results);
+        $combined = \IROChatGPT\combine_annotation_response_results($applied['response_results']);
+
+        assert_same(null, $applied['error_code']);
+        assert_same(null, $combined['error_code']);
+        assert_same(
+            ['existing' => 'valid', 'first' => 'valid', 'second' => 'also valid'],
+            $combined['annotations']
+        );
+    },
+    'stops after the bounded retry if a smaller response is still truncated' => function () {
+        $truncated = \IROChatGPT\annotation_response_failure(
+            'model_output_truncated',
+            'Model output reached its token limit',
+            'length'
+        );
+        $retry_results = [[
+            \IROChatGPT\parse_annotation_response(annotation_api_response('{"first":"valid"}')),
+            $truncated,
+        ]];
+        $applied = \IROChatGPT\apply_annotation_retry_results([$truncated], $retry_results);
+
+        assert_same('retry_failed', $applied['error_code']);
+        assert_same(0, $applied['failed_segment']);
+    },
+    'fails the whole operation after a later invalid response' => function () {
+        $stored_annotations = ['existing' => 'preserved'];
+        $response_results = [
+            \IROChatGPT\parse_annotation_response(annotation_api_response('{"first":"valid"}')),
+            \IROChatGPT\parse_annotation_response(annotation_api_response('{"second":"truncated"')),
+        ];
+        $combined = \IROChatGPT\combine_annotation_response_results($response_results);
+
+        if ($combined['error_code'] === null) {
+            $stored_annotations = $combined['annotations'];
+        }
+
+        assert_same('segment_failure', $combined['error_code']);
+        assert_same([], $combined['annotations']);
+        assert_same(1, $combined['failed_segment']);
+        assert_same(['existing' => 'preserved'], $stored_annotations);
+    },
+];
+
+$failures = [];
+foreach ($tests as $description => $test) {
+    try {
+        $test();
+        echo ". $description\n";
+    } catch (Throwable $error) {
+        $failures[$description] = $error->getMessage();
+        echo "F $description\n";
+    }
+}
+
+echo count($tests) . ' tests, ' . count($failures) . " failures\n";
+foreach ($failures as $description => $message) {
+    echo "\n$description\n$message\n";
+}
+
+exit(count($failures) === 0 ? 0 : 1);

--- a/inc/chatgpt/hooks.php
+++ b/inc/chatgpt/hooks.php
@@ -8,6 +8,8 @@ namespace IROChatGPT {
     define("DEFAULT_INIT_PROMPT", "请以作者的身份，以激发好奇吸引阅读为目的，结合文章核心观点来提取的文章中最吸引人的内容，为以下文章编写一个用词精炼简短、90字以内、与文章语言一致的引言。");
     define("DEFAULT_MODEL", "gpt-4o-mini");
 
+    require_once __DIR__ . '/annotation-response.php';
+
     function generate_post_summary(WP_Post $post)
     {
         $exclude_ids = iro_opt('chatgpt_exclude_ids', '');
@@ -125,9 +127,6 @@ namespace IROChatGPT {
         curl_close($ch);
         // === 替换结束 ===
 
-        // 输出 API 原始响应调试信息
-        error_log("GPT error: " . $chat);
-
         $decoded_chat = json_decode($chat);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
@@ -135,7 +134,7 @@ namespace IROChatGPT {
         }
 
         if (is_null($decoded_chat) || isset($decoded_chat->error)) {
-            throw new Exception("ChatGPT error: " . json_encode($decoded_chat));
+            throw new Exception("ChatGPT API returned an error.");
         }
 
         return $decoded_chat->choices[0]->message->content;
@@ -177,25 +176,129 @@ namespace IROChatGPT {
         }
     }
 
+    function request_annotation_segments($segments, $api_endpoint, $api_key, $model, $prompt, $timeout, $attempt)
+    {
+        $attempt = $attempt === 'retry' ? 'retry' : 'initial';
+        $parsed_responses = [];
+        $mh = curl_multi_init();
+        $curl_handles = [];
+
+        foreach ($segments as $index => $segment) {
+            $data = [
+                'model' => $model,
+                'messages' => [
+                    [
+                        'role' => 'system',
+                        'content' => '你是一个专业的文章分析助手，擅长识别文章中专业术语、复杂概念、事件、社会热点、网络黑话烂梗热词、晦涩难懂等内容并提供简明解释。'
+                    ],
+                    [
+                        'role' => 'user',
+                        'content' => $prompt . $segment
+                    ]
+                ],
+                'temperature' => 0.3,
+                'max_tokens' => ANNOTATION_OUTPUT_TOKEN_LIMIT
+            ];
+            $headers = [
+                'Content-Type: application/json',
+                'Authorization: Bearer ' . $api_key
+            ];
+            $request_body = json_encode($data, JSON_UNESCAPED_UNICODE);
+            if ($request_body === false) {
+                $parsed_responses[$index] = annotation_response_failure(
+                    'request_json_error',
+                    'Unable to encode annotation request'
+                );
+                continue;
+            }
+
+            $ch = curl_init($api_endpoint);
+            if ($ch === false) {
+                $parsed_responses[$index] = annotation_response_failure(
+                    'curl_init_error',
+                    'Unable to initialize cURL'
+                );
+                continue;
+            }
+
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $request_body);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+            curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+
+            if (curl_multi_add_handle($mh, $ch) !== CURLM_OK) {
+                $parsed_responses[$index] = annotation_response_failure(
+                    'curl_multi_error',
+                    'Unable to queue annotation request'
+                );
+                curl_close($ch);
+                continue;
+            }
+            $curl_handles[$index] = $ch;
+        }
+
+        if (!empty($curl_handles)) {
+            $running = null;
+            do {
+                $status = curl_multi_exec($mh, $running);
+                usleep(100000);
+            } while ($running > 0 && $status == CURLM_OK);
+        }
+
+        foreach ($curl_handles as $index => $ch) {
+            $response = curl_multi_getcontent($ch);
+            $curl_errno = curl_errno($ch);
+            $http_status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $parsed_response = parse_annotation_response($response, $curl_errno, $http_status);
+            $parsed_responses[$index] = $parsed_response;
+
+            if ($parsed_response['error_code'] === null) {
+                error_log(sprintf(
+                    'IROChatGPT: 注释响应成功: attempt=%s, segment=%s, annotations=%d',
+                    $attempt,
+                    (string) $index,
+                    count($parsed_response['annotations'])
+                ));
+            } else {
+                error_log(sprintf(
+                    'IROChatGPT: 注释响应处理失败: attempt=%s, segment=%s, error=%s, HTTP=%d, cURL=%d, finish_reason=%s, response_length=%d, detail=%s',
+                    $attempt,
+                    (string) $index,
+                    $parsed_response['error_code'],
+                    $http_status,
+                    $curl_errno,
+                    $parsed_response['finish_reason'] ?? 'none',
+                    strlen((string) $response),
+                    $parsed_response['error_message']
+                ));
+            }
+
+            curl_multi_remove_handle($mh, $ch);
+            curl_close($ch);
+        }
+        curl_multi_close($mh);
+
+        return $parsed_responses;
+    }
+
     /**
      * 调用ChatGPT API生成复杂名词注释
      */
     function call_chatgpt_for_annotations($content)
     {
-        // 使用正确的选项名获取API配置
         $api_endpoint = iro_opt('chatgpt_endpoint', 'https://api.openai.com/v1/chat/completions');
         $api_key = iro_opt('chatgpt_access_token', '');
         $model = iro_opt('chatgpt_model', 'gpt-4o-mini');
 
-        // 如果找不到API密钥，返回空数组
         if (empty($api_key)) {
             error_log('IROChatGPT: No API key found');
             return [];
         }
 
         $max_length = iro_opt("chatgpt_max_tokens", 7000);
-
-        // 截取内容
         $paragraphs = preg_split('/\n\s*\n/', $content);
         $segments = [];
         $current_segment = '';
@@ -214,95 +317,92 @@ namespace IROChatGPT {
             $segments[] = $current_segment;
         }
 
-        $mh = curl_multi_init();
-        $curl_handles = [];
+        $prompt = iro_opt("chatgpt_annotations_prompt");
+        if (empty($prompt)) {
+            $prompt = "分析以下文章正文内容(排除标题及引语类文本)，用最认真的态度和较为严格的识别标准筛选出专业术语、复杂概念、事件、社会热点、网络黑话烂梗热词、晦涩难懂、与文章语言不同的名词，并根据文章主要语言提供对应语言的简短解释。若文章出现与“事件”，“热点”，“介绍”等具有提示上下文功能的含义的名词时，请务必用最高优先级在前后查找符合要求的名词。名词选取时需要排除日常常用的名词、非著名人物的人名。仅返回JSON格式，格式为：{\"术语1\":\"解释1\", \"术语2\":\"解释2\", ...}。注意不要出现在原文中并没有出现的名词，生成的名词越多越好：\n\n";
+        }
+        $timeout = max(5, min(360, (int) iro_opt('chatgpt_api_request_timeout', 30)));
 
-        // 为每个分段构建请求
-        foreach ($segments as $index => $segment) {
-            // 构建每个分段的提示词
-            $prompt = iro_opt("chatgpt_annotations_prompt");
-            if (empty($prompt)) {
-                $prompt = "分析以下文章正文内容(排除标题及引语类文本)，用最认真的态度和较为严格的识别标准筛选出专业术语、复杂概念、事件、社会热点、网络黑话烂梗热词、晦涩难懂、与文章语言不同的名词，并根据文章主要语言提供对应语言的简短解释。若文章出现与“事件”，“热点”，“介绍”等具有提示上下文功能的含义的名词时，请务必用最高优先级在前后查找符合要求的名词。名词选取时需要排除日常常用的名词、非著名人物的人名。仅返回JSON格式，格式为：{\"术语1\":\"解释1\", \"术语2\":\"解释2\", ...}。注意不要出现在原文中并没有出现的名词，生成的名词越多越好：\n\n";
-            }
-            // 拼接提示词和分段内容
-            $full_prompt = $prompt . $segment;
+        $parsed_responses = request_annotation_segments(
+            $segments,
+            $api_endpoint,
+            $api_key,
+            $model,
+            $prompt,
+            $timeout,
+            'initial'
+        );
 
-            // 构建请求数据
-            $data = [
-                'model' => $model,
-                'messages' => [
-                    [
-                        'role' => 'system',
-                        'content' => '你是一个专业的文章分析助手，擅长识别文章中专业术语、复杂概念、事件、社会热点、网络黑话烂梗热词、晦涩难懂等内容并提供简明解释。'
-                    ],
-                    [
-                        'role' => 'user',
-                        'content' => $full_prompt
-                    ]
-                ],
-                'temperature' => 0.3,
-                'max_tokens' => 800
-            ];
-
-            // 设置 HTTP 请求头
-            $headers = [
-                'Content-Type: application/json',
-                'Authorization: Bearer ' . $api_key
-            ];
-
-            // 初始化单个curl
-            $ch = curl_init($api_endpoint);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($ch, CURLOPT_POST, true);
-            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
-            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-            curl_setopt($ch, CURLOPT_TIMEOUT, iro_opt('chatgpt_api_request_timeout', 30));
-
-            // 添加到multi
-            curl_multi_add_handle($mh, $ch);
-            $curl_handles[$index] = $ch;
+        $retry_plan = build_annotation_retry_plan($segments, $parsed_responses);
+        if ($retry_plan['error_code'] !== null) {
+            error_log(sprintf(
+                'IROChatGPT: 注释生成失败且不可重试: error=%s, failed_segment=%s',
+                $retry_plan['error_code'],
+                (string) $retry_plan['failed_segment']
+            ));
+            return [];
         }
 
-        // 并发所有请求
-        $running = null;
-        do {
-            $status = curl_multi_exec($mh, $running);
-            usleep(100000);
-        } while ($running > 0 && $status == CURLM_OK);
+        if (!empty($retry_plan['retry_segments'])) {
+            $retry_segments = [];
+            $retry_segment_map = [];
+            $retry_index = 0;
 
-        // 整合所有响应
-        $annotations = [];
-        foreach ($curl_handles as $ch) {
-            $response = curl_multi_getcontent($ch);
-            // 记录部分日志
-            error_log('IROChatGPT: API返回响应: ' . substr($response, 0, 200) . '...');
-
-            $result = json_decode($response, true);
-            if (isset($result['choices'][0]['message']['content'])) {
-                $json_str = $result['choices'][0]['message']['content'];
-                error_log('IROChatGPT: 提取的JSON: ' . $json_str);
-                if (preg_match('/\{.*\}/s', $json_str, $matches)) {
-                    $segment_annotations = json_decode($matches[0], true);
+            foreach ($retry_plan['retry_segments'] as $segment_index => $parts) {
+                foreach ($parts as $part) {
+                    $retry_segments[$retry_index] = $part;
+                    $retry_segment_map[$segment_index][] = $retry_index;
+                    $retry_index++;
                 }
-                if (is_array($segment_annotations)) {
-                    // 合并注释结果
-                    error_log('IROChatGPT: 成功解析JSON，获取到 ' . count($segment_annotations) . ' 个注释');
-                    $annotations = array_merge($annotations, $segment_annotations);
-                } else {
-                    error_log('IROChatGPT: JSON解析失败: ' . json_last_error_msg());
-                }
-            } else {
-                error_log('IROChatGPT: 未能从响应中提取目标内容，响应内容: ' . $response);
             }
 
-            // 移除并关闭句柄
-            curl_multi_remove_handle($mh, $ch);
-            curl_close($ch);
-        }
-        curl_multi_close($mh);
+            error_log(sprintf(
+                'IROChatGPT: 重试被截断的注释响应: attempt=%d, segments=%d, requests=%d',
+                ANNOTATION_MAX_RETRY_ATTEMPTS,
+                count($retry_plan['retry_segments']),
+                count($retry_segments)
+            ));
 
-        return $annotations;
+            $flat_retry_results = request_annotation_segments(
+                $retry_segments,
+                $api_endpoint,
+                $api_key,
+                $model,
+                $prompt,
+                $timeout,
+                'retry'
+            );
+            $retry_results = [];
+
+            foreach ($retry_segment_map as $segment_index => $retry_indexes) {
+                foreach ($retry_indexes as $retry_result_index) {
+                    $retry_results[$segment_index][$retry_result_index] = $flat_retry_results[$retry_result_index]
+                        ?? annotation_response_failure('response_missing', 'Retry response is missing');
+                }
+            }
+
+            $applied_retry = apply_annotation_retry_results($parsed_responses, $retry_results);
+            if ($applied_retry['error_code'] !== null) {
+                error_log(sprintf(
+                    'IROChatGPT: 注释重试失败，未保存部分结果: failed_segment=%s',
+                    (string) $applied_retry['failed_segment']
+                ));
+                return [];
+            }
+
+            $parsed_responses = $applied_retry['response_results'];
+        }
+
+        $combined_response = combine_annotation_response_results($parsed_responses);
+        if ($combined_response['error_code'] !== null) {
+            error_log(sprintf(
+                'IROChatGPT: 注释生成整体失败，未保存部分结果: failed_segment=%s',
+                (string) $combined_response['failed_segment']
+            ));
+            return [];
+        }
+
+        return $combined_response['annotations'];
     }
 
     /**
@@ -317,7 +417,7 @@ namespace IROChatGPT {
         }
         $annotations = get_post_meta($post->ID, 'iro_chatgpt_annotations', true);
 
-        if (empty($annotations) || !is_array($annotations)) {
+        if (empty($annotations) || !is_string_annotation_map($annotations)) {
             return $original_content; // Return original if no data
         }
 
@@ -460,7 +560,11 @@ namespace IROChatGPT {
                             if (!$isOverlapped) {
                                 // Found the first non-overlapping occurrence in this node
                                 $annotationIndex = $annotationMap[$term];
-                                $termEscaped = htmlspecialchars($term, ENT_QUOTES);
+                                $termEscaped = htmlspecialchars(
+                                    $term,
+                                    ENT_QUOTES | ENT_XML1 | ENT_SUBSTITUTE,
+                                    'UTF-8'
+                                );
                                 // Use locale-specific brackets
                                 $supHtml = '<sup class="iro-term-annotation" data-term="' . $termEscaped . '" data-id="' . $annotationIndex . '">' . $opening_bracket . $annotationIndex . $closing_bracket . '</sup>';
 

--- a/inc/swicher.php
+++ b/inc/swicher.php
@@ -150,6 +150,18 @@ function font_end_js_control()
     $sakura_effect = iro_opt('sakura_falling_effects');
     if ($sakura_effect != 'off') $iro_opt['effect'] = array('amount' => $sakura_effect);
     if (iro_opt('theme_darkmode_auto')) $iro_opt['dm_strategy'] = iro_opt('theme_darkmode_strategy', 'time');
-    wp_add_inline_script('app', 'var _iro = ' . json_encode($iro_opt, JSON_NUMERIC_CHECK | JSON_UNESCAPED_UNICODE), 'before');
+    wp_add_inline_script(
+        'app',
+        'var _iro = ' . wp_json_encode(
+            $iro_opt,
+            JSON_NUMERIC_CHECK
+            | JSON_UNESCAPED_UNICODE
+            | JSON_HEX_TAG
+            | JSON_HEX_AMP
+            | JSON_HEX_APOS
+            | JSON_HEX_QUOT
+        ),
+        'before'
+    );
 }
 add_action('wp_head', 'font_end_js_control');


### PR DESCRIPTION
## Summary
- Validate OpenAI-compatible annotation responses and log bounded diagnostics without provider payloads.
- Retry token-truncated segments once after UTF-8-safe splitting and save only complete results.
- Harden annotation admin/rendering data handling and inline JSON output.

Closes #1412

## Testing
- php inc/chatgpt/annotation-response.test.php (29 tests, 0 failures)
- PHP syntax checks for all changed PHP files
- git diff --check

## Risks
- No live provider or WordPress integration testing was performed; provider-specific response variants and admin UI behavior remain integration risks.