### PR TITLE
修复一处 css 语法错误；优化评论区艾特样式

### DIFF
--- a/style.css
+++ b/style.css
@@ -4749,8 +4749,10 @@ span.page-numbers.dots, a.page-numbers {
   text-decoration: underline;
 }
 
-.comment .body .comment-at {
-  color: var(--theme-skin, #505050);
+/* 评论区@优化为高亮显示 */
+.comment .body .comment-at,
+body.dark .comment .body .comment-at {
+  color: var(--article-theme-highlight, var(--theme-skin-matching, #505050)) !important;
   text-decoration: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -4744,7 +4744,7 @@ span.page-numbers.dots, a.page-numbers {
 }
 
 .comment .body p a {
-  color: var(--article-theme-highlight,var(--theme-skin-matching), #505050);
+  color: var(--article-theme-highlight,var(--theme-skin-matching, #505050));
   padding: 0 5px;
   text-decoration: underline;
 }


### PR DESCRIPTION
# 1. 修复一处 css 语法错误

在 /style.css 第 ~4770 行

```diff
.comment .body p a {
-   color: var(--article-theme-highlight,var(--theme-skin-matching), #505050);
+   color: var(--article-theme-highlight,var(--theme-skin-matching, #505050));
  padding: 0 5px;
  text-decoration: underline;
}
```

`var()` 函数最多接受两个参数（自定义变量名 + 回退值），这里传了三个参数，应该是括号位置打错了，予以修复。

# 2. 优化评论区艾特样式

在 /style.css 第 ~4775 行

```diff
- .comment .body .comment-at {
-   color: var(--theme-skin, #505050);
+ /* 评论区@优化为高亮显示 */
+ .comment .body .comment-at,
+ body.dark .comment .body .comment-at {
+   color: var(--article-theme-highlight, var(--theme-skin-matching, #505050)) !important;
  text-decoration: none;
}
```

将评论区@的样式改为高亮显示，原本的灰色与正文同色，区分不明显。