### PR TITLE
fix: 修复回复评论中可能会多次添加@的bug

### DIFF
--- a/author.php
+++ b/author.php
@@ -12,7 +12,7 @@ get_header();
         <div class="description">
             <?php 
             $description = get_the_author_meta('description');
-            echo $description ? nl2br($description) : __("No personal profile set yet", "sakurairo"); 
+            echo $description ? wp_kses_post(nl2br($description)) : esc_html__("No personal profile set yet", "sakurairo"); 
             ?>
         </div>
     </div>
@@ -53,7 +53,7 @@ get_header();
     </main><!-- #main -->
     <?php if (iro_opt('pagenav_style') == 'ajax') : ?>
         <div id="pagination"><?php next_posts_link(__(' Previous', 'sakurairo')); ?></div>
-        <div id="add_post"><span id="add_post_time" style="visibility: hidden;" title="<?php echo iro_opt('page_auto_load', ''); ?>"></span></div>
+        <div id="add_post"><span id="add_post_time" style="visibility: hidden;" title="<?php echo esc_attr(iro_opt('page_auto_load', '')); ?>"></span></div>
     <?php else : ?>
         <nav class="navigator">
 	    <?php 

--- a/comments.php
+++ b/comments.php
@@ -189,6 +189,7 @@ function get_smilies_panel() {
                                                 <input type="checkbox" id="enable_markdown" name="enable_markdown">
                                                 <i class="fa-brands fa-markdown fa-sm"></i>
                                             </label>
+                                            ' . wp_nonce_field('sakurairo_ajax_comment', 'sakurairo_comment_nonce', true, false) . '
                                         </div>',
                 'comment_notes_after'  => '',
                 'comment_notes_before' => '',

--- a/exhibition.php
+++ b/exhibition.php
@@ -343,7 +343,7 @@ if ($need_medals) {
 
 <div class="exhibition-area-container">
     <h1 class="fes-title"> 
-        <i class="<?php echo iro_opt('exhibition_area_icon', 'fa-solid fa-laptop'); ?>" aria-hidden="true"></i> <?php echo iro_opt('exhibition_area_title', '展示'); ?> 
+        <i class="<?php echo esc_attr(iro_opt('exhibition_area_icon', 'fa-solid fa-laptop')); ?>" aria-hidden="true"></i> <?php echo esc_html(iro_opt('exhibition_area_title', '展示')); ?>
     </h1>
       <!-- Bento布局容器 -->
        <div class="bento-grid">
@@ -364,10 +364,10 @@ if ($need_medals) {
                     case 'admin_online':
                         ?>
                         <div class="stat-capsule">
-                          <i class="<?php echo $square_cards[$component]['icon']; ?>"></i>
+                          <i class="<?php echo esc_attr($square_cards[$component]['icon']); ?>"></i>
                           <div class="capsule-content">
-                            <span class="capsule-label"><?php echo $square_cards[$component]['label']; ?></span>
-                            <span class="capsule-value"><?php echo $square_cards[$component]['value']; ?></span>
+                            <span class="capsule-label"><?php echo esc_html($square_cards[$component]['label']); ?></span>
+                            <span class="capsule-value"><?php echo esc_html($square_cards[$component]['value']); ?></span>
                           </div>
                         </div>
                         <?php
@@ -380,9 +380,9 @@ if ($need_medals) {
                         // 如果有对应徽章，就渲染徽章，否则渲染普通卡片
                         if (isset($medal_levels[$component])): 
                             $medal = $medal_levels[$component]; ?>
-                            <div class="stat-capsule medal-capsule <?php echo $medal['type']; ?>" 
-                                 data-medal-type="<?php echo $component; ?>"
-                                 data-medal-level="<?php echo $medal['type']; ?>"
+                            <div class="stat-capsule medal-capsule <?php echo esc_attr($medal['type']); ?>" 
+                                 data-medal-type="<?php echo esc_attr($component); ?>"
+                                 data-medal-level="<?php echo esc_attr($medal['type']); ?>"
                                  <?php if (isset($medal['achievement'])) : ?>
                                  data-achievement="<?php echo esc_attr($medal['achievement']); ?>"
                                  <?php endif; ?>
@@ -397,28 +397,28 @@ if ($need_medals) {
                                 </div>
                                 <i class="fa-solid fa-medal"></i>
                                 <div class="capsule-content">
-                                    <span class="capsule-label"><?php echo $medal['label']; ?></span>
+                                    <span class="capsule-label"><?php echo esc_html($medal['label']); ?></span>
                                     <span class="capsule-value">
-                                    <?php echo $square_cards[$component]['value']; ?>
+                                    <?php echo esc_html($square_cards[$component]['value']); ?>
                                     </span>
                                 </div>
                                 <div class="medal-info-tooltip">
                                     <div class="medal-achievement">
-                                        <?php echo isset($medal['achievement']) ? $medal['achievement'] : ''; ?>
+                                        <?php echo isset($medal['achievement']) ? esc_html($medal['achievement']) : ''; ?>
                                     </div>
                                     <?php if (isset($medal['next_level'])) : ?>
                                     <div class="medal-next-level">
-                                        <?php echo $medal['next_level']; ?>
+                                        <?php echo esc_html($medal['next_level']); ?>
                                     </div>
                                     <?php endif; ?>
                                 </div>
                             </div>
                         <?php else: ?>
                             <div class="stat-capsule">
-                                <i class="<?php echo $square_cards[$component]['icon']; ?>"></i>
+                                <i class="<?php echo esc_attr($square_cards[$component]['icon']); ?>"></i>
                                 <div class="capsule-content">
-                                <span class="capsule-label"><?php echo $square_cards[$component]['label']; ?></span>
-                                <span class="capsule-value"><?php echo $square_cards[$component]['value']; ?></span>
+                                <span class="capsule-label"><?php echo esc_html($square_cards[$component]['label']); ?></span>
+                                <span class="capsule-value"><?php echo esc_html($square_cards[$component]['value']); ?></span>
                                 </div>
                             </div>
                         <?php endif;
@@ -456,10 +456,10 @@ if ($need_medals) {
                                 list($first,$second) = $lines;
                             } ?>
                             <div class="stat-capsule announcement-capsule">
-                            <i class="<?php echo $square_cards['announcement']['icon']; ?>"></i>
+                            <i class="<?php echo esc_attr($square_cards['announcement']['icon']); ?>"></i>
                             <div class="capsule-content">
-                                <span class="announcement-line first-line"><?php echo $first; ?></span>
-                                <span class="announcement-line second-line"><?php echo $second; ?></span>
+                                <span class="announcement-line first-line"><?php echo esc_html($first); ?></span>
+                                <span class="announcement-line second-line"><?php echo esc_html($second); ?></span>
                             </div>
                             </div>
                         <?php endif;

--- a/functions.php
+++ b/functions.php
@@ -3610,18 +3610,22 @@ if (iro_opt('captcha_select') === 'iro_captcha') {
 // 获取访客 IP
 function get_the_user_ip()
 {
-    // if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
-    //     //check ip from share internet
-    //     $ip = $_SERVER['HTTP_CLIENT_IP'];
-    // } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-    //     //to check ip is pass from proxy
-    //     $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-    // } else {
-    //     $ip = $_SERVER['REMOTE_ADDR'];
-    // }
-    // 简略版
-    // $ip = $_SERVER['HTTP_CLIENT_IP'] ?: ($_SERVER['HTTP_X_FORWARDED_FOR'] ?: $_SERVER['REMOTE_ADDR']);
-    $ip = $_SERVER['HTTP_CLIENT_IP'] ?? $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'];
+    // CDN/反向代理场景：从 X-Forwarded-For 取最右侧（最接近源站）的 IP
+    // CDN 会将真实访客 IP 追加到链尾，取最右侧可抵抗在链首插入伪造 IP 的攻击
+    // 不信任 HTTP_CLIENT_IP（非标准头，纯伪造向量）
+    $ip = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
+    // 仅在站点位于反向代理/CDN 之后时才应信任 X-Forwarded-For；
+    // 直接对外暴露的站点可通过该过滤器返回 false 以彻底拒绝 XFF 伪造
+    $trust_forwarded = apply_filters('sakura_trust_x_forwarded_for', true);
+    if ($trust_forwarded && !empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        $forwarded_chain = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
+        $candidate = trim(end($forwarded_chain));
+        // 验证为合法 IPv4/IPv6，否则回退到 REMOTE_ADDR
+        if (filter_var($candidate, FILTER_VALIDATE_IP)) {
+            $ip = $candidate;
+        }
+    }
+
     return apply_filters('wpb_get_ip', $ip);
 }
 

--- a/functions.php
+++ b/functions.php
@@ -12,7 +12,7 @@ include_once('inc/classes/IpLocation.php');
 
 define('IRO_VERSION', wp_get_theme()->get('Version'));
 define('BUILD_VERSION', '3');
-define('INT_VERSION', '20.0.10');
+define('INT_VERSION', '20.0.11');
 define('SSU_URL', 'https://api.fuukei.org/update/ssu.json');
 
 function check_php_version($preset_version)

--- a/functions.php
+++ b/functions.php
@@ -1766,7 +1766,7 @@ function remove_dashboard()
             preg_match('#wp-admin/?(index.php)?$#', $_SERVER['REQUEST_URI']) &&
             ('index.php' != $menu[$page][2])
         ) {
-            wp_redirect(get_option('siteurl') . '/wp-admin/profile.php');
+            wp_safe_redirect(admin_url('profile.php'));
         }
     }
 }
@@ -2418,13 +2418,18 @@ function change_avatar($avatar)
     global $comment, $sakura_privkey;
     if ($comment && get_comment_meta($comment->comment_ID, 'new_field_qq', true)) {
         $qq_number = get_comment_meta($comment->comment_ID, 'new_field_qq', true);
+        $qq_number = sanitize_text_field($qq_number);
         if (iro_opt('qq_avatar_link') == 'off') {
-            return '<img src="https://q2.qlogo.cn/headimg_dl?dst_uin=' . $qq_number . '&spec=100" class="lazyload avatar avatar-24 photo" alt="😀" width="24" height="24" onerror="imgError(this,1)">';
+            return '<img src="https://q2.qlogo.cn/headimg_dl?dst_uin=' . esc_attr($qq_number) . '&spec=100" class="lazyload avatar avatar-24 photo" alt="😀" width="24" height="24" onerror="imgError(this,1)">';
         }
         if (iro_opt('qq_avatar_link') == 'type_3') {
-            $qqavatar = file_get_contents('http://ptlogin2.qq.com/getface?appid=1006102&imgtype=3&uin=' . $qq_number);
+            $qqavatar = wp_remote_retrieve_body(wp_remote_get('https://ptlogin2.qq.com/getface?appid=1006102&imgtype=3&uin=' . urlencode($qq_number)));
             preg_match('/:\"([^\"]*)\"/i', $qqavatar, $matches);
-            return '<img src="' . $matches[1] . '" class="lazyload avatar avatar-24 photo" alt="😀" width="24" height="24" onerror="imgError(this,1)">';
+            $avatar_url = isset($matches[1]) ? esc_url($matches[1]) : '';
+            if (empty($avatar_url)) {
+                return $avatar;
+            }
+            return '<img src="' . $avatar_url . '" class="lazyload avatar avatar-24 photo" alt="😀" width="24" height="24" onerror="imgError(this,1)">';
         }
         
         // Ensure $sakura_privkey is defined and not null
@@ -2439,10 +2444,10 @@ function change_avatar($avatar)
             // 将初始化向量和加密数据一起编码
             $encrypted = urlencode(base64_encode($iv . $encrypted));
             
-            return '<img src="' . rest_url("sakura/v1/qqinfo/avatar") . '?qq=' . $encrypted . '" class="lazyload avatar avatar-24 photo" alt="😀" width="24" height="24" onerror="imgError(this,1)">';
+            return '<img src="' . esc_url(rest_url("sakura/v1/qqinfo/avatar") . '?qq=' . $encrypted) . '" class="lazyload avatar avatar-24 photo" alt="😀" width="24" height="24" onerror="imgError(this,1)">';
         } else {
             // Handle the case where $sakura_privkey is not set or is null
-            return '<img src="default_avatar_url" class="lazyload avatar avatar-24 photo" alt="😀" width="24" height="24" onerror="imgError(this,1)">';
+            return $avatar;
         }
     }
     return $avatar;
@@ -4522,9 +4527,9 @@ function iro_action_operator()
                 WP_Filesystem();
                 global $wp_filesystem;
                 $wp_filesystem->delete(get_theme_root() . '/Sakurairo', true);
-                wp_redirect(admin_url(), 302); //重载theme_folder_check_on_admin_init流程
+                wp_safe_redirect(admin_url(), 302); //重载theme_folder_check_on_admin_init流程
             } else {
-                wp_redirect(admin_url(), 302);
+                wp_safe_redirect(admin_url(), 302);
                 return;
             }
     }

--- a/functions.php
+++ b/functions.php
@@ -756,9 +756,12 @@ if (!function_exists('akina_comment_format')) {
 function get_author_class($comment_author_email, $user_id)
 {
     global $wpdb;
-    $author_count = count(
-        $wpdb->get_results(
-            "SELECT comment_ID as author_count FROM $wpdb->comments WHERE comment_author_email = '$comment_author_email' "
+    // 安全修复：用 prepare 参数化查询防止 SQL 注入
+    // 性能优化：用 COUNT(*) + get_var 替代 get_results + count（语义完全等价）
+    $author_count = (int) $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_author_email = %s",
+            $comment_author_email
         )
     );
     # 等级梯度

--- a/inc/api.php
+++ b/inc/api.php
@@ -152,6 +152,22 @@ add_action('rest_api_init', function () {
 require_once ('chatgpt/hooks.php');
 require_once ('chatgpt/chatgpt.php');
 
+function sakura_get_rest_request_nonce(WP_REST_Request $request)
+{
+    $nonce = $request->get_header('X-WP-Nonce');
+    if (!$nonce) {
+        $nonce = $request->get_param('_wpnonce');
+    }
+
+    return $nonce ? sanitize_text_field(wp_unslash($nonce)) : '';
+}
+
+function sakura_verify_rest_request_nonce(WP_REST_Request $request)
+{
+    $nonce = sakura_get_rest_request_nonce($request);
+    return $nonce && wp_verify_nonce($nonce, 'wp_rest');
+}
+
 function chatgpt_summarize(WP_REST_Request $request)
 {
     $post_id = $request->get_param('post_id');
@@ -201,7 +217,7 @@ function upload_image(WP_REST_Request $request)
      *   https://dev.2heng.xin/wp-json/sakura/v1/image/upload
      */
     // $file = $request->get_file_params();
-    if (!check_ajax_referer('wp_rest', '_wpnonce', false)) {
+    if (!sakura_verify_rest_request_nonce($request)) {
         $output = array(
             'status' => 403,
             'success' => false,
@@ -212,21 +228,30 @@ function upload_image(WP_REST_Request $request)
         return $result;
     }
     $images = new \Sakura\API\Images();
+    $files = $request->get_file_params();
+    // 验证上传文件存在且可读
+    if (empty($files['cmt_img_file']['tmp_name']) || !is_readable($files['cmt_img_file']['tmp_name'])) {
+        return new WP_REST_Response(array(
+            'status' => 400,
+            'success' => false,
+            'message' => 'Missing or invalid upload file.'
+        ), 400);
+    }
     switch (iro_opt("img_upload_api")) {
         case 'imgur':
-            $image = file_get_contents($_FILES["cmt_img_file"]["tmp_name"]);
+            $image = file_get_contents($files["cmt_img_file"]["tmp_name"]);
             $API_Request = $images->Imgur_API($image);
             break;
         case 'smms':
-            $image = $_FILES;
+            $image = $files;
             $API_Request = $images->SMMS_API($image);
             break;
         case 'chevereto':
-            $image = file_get_contents($_FILES["cmt_img_file"]["tmp_name"]);
+            $image = file_get_contents($files["cmt_img_file"]["tmp_name"]);
             $API_Request = $images->Chevereto_API($image);
             break;
         case 'lsky':
-            $image = $_FILES;
+            $image = $files;
             $API_Request = $images->LSKY_API($image);
             break;
     }
@@ -255,9 +280,9 @@ function upload_image(WP_REST_Request $request)
  * @rest api接口路径：https://sakura.2heng.xin/wp-json/sakura/v1/cache_search/json
  * @可在cache_search_json()函数末尾通过设置 HTTP header 控制 json 缓存时间
  */
-function cache_search_json()
+function cache_search_json(WP_REST_Request $request)
 {
-    if (!check_ajax_referer('wp_rest', '_wpnonce', false)) {
+    if (!sakura_verify_rest_request_nonce($request)) {
         $output = array(
             'status' => 403,
             'success' => false,
@@ -283,21 +308,23 @@ function cache_search_json()
  */
 function get_qq_info(WP_REST_Request $request)
 {
-    if (!check_ajax_referer('wp_rest', '_wpnonce', false)) {
+    if (!sakura_verify_rest_request_nonce($request)) {
         $output = array(
             'status' => 403,
             'success' => false,
             'message' => 'Unauthorized client.'
         );
-    } elseif ($_GET['qq']) {
-        $qq = $_GET['qq'];
-        $output = QQ::get_qq_info($qq);
     } else {
-        $output = array(
-            'status' => 400,
-            'success' => false,
-            'message' => 'Bad Request'
-        );
+        $qq = sanitize_text_field($request->get_param('qq'));
+        if (empty($qq)) {
+            $output = array(
+                'status' => 400,
+                'success' => false,
+                'message' => 'Bad Request'
+            );
+        } else {
+            $output = QQ::get_qq_info($qq);
+        }
     }
 
     $result = new WP_REST_Response($output, $output['status']);
@@ -309,103 +336,100 @@ function get_qq_info(WP_REST_Request $request)
  * QQ头像链接解密
  * https://sakura.2heng.xin/wp-json/sakura/v1/qqinfo/avatar
  */
-function get_qq_avatar()
+function get_qq_avatar(WP_REST_Request $request)
 {
-    $encrypted = $_GET["qq"];
+    $encrypted = sanitize_text_field($request->get_param('qq'));
+    if (empty($encrypted)) {
+        return new WP_REST_Response(array('status' => 400, 'message' => 'Missing qq parameter'), 400);
+    }
     $imgurl = QQ::get_qq_avatar($encrypted);
+    if (!$imgurl) {
+        return new WP_REST_Response(array('status' => 404, 'message' => 'Avatar not found'), 404);
+    }
     if (iro_opt('qq_avatar_link') == 'type_2') {
-        $imgdata = file_get_contents($imgurl);
-        $response = new WP_REST_Response();
-        $response->set_headers(
-            array(
-                'Content-Type' => 'image/jpeg',
-                'Cache-Control' => 'max-age=86400'
-            )
-        );
+        $imgdata = wp_remote_retrieve_body(wp_remote_get(esc_url_raw($imgurl)));
+        if (empty($imgdata)) {
+            return new WP_REST_Response(array('status' => 500, 'message' => 'Failed to fetch avatar'), 500);
+        }
+        // 二进制数据需直接输出，避免 REST 框架 JSON 编码导致响应损坏
+        header('Content-Type: image/jpeg');
+        header('Cache-Control: max-age=86400');
         echo $imgdata;
+        exit;
     } else {
         $response = new WP_REST_Response();
-        $response->set_status(301);
-        $response->header('Location', $imgurl);
+        $response->set_status(302);
+        $response->header('Location', esc_url_raw($imgurl));
     }
     return $response;
 }
 
-function bgm_bangumi($request)
+function bgm_bangumi(WP_REST_Request $request)
 {
-    if (!check_ajax_referer('wp_rest', '_wpnonce', false)) {
+    if (!sakura_verify_rest_request_nonce($request)) {
         $response = array(
             'status' => 418,
             'success' => false,
             'message' => 'Unauthorized client.'
         );
         return new WP_REST_Response($response, 418);
-    } else {
-        $userID = $request->get_param('userID');
-        $page = $request->get_param('page') ?: 1;
-        $bgmList = new \Sakura\API\BangumiList();
     }
-    return $bgmList->get_bgm_items($userID, (int)$page);
+    $userID = sanitize_text_field($request->get_param('userID'));
+    $page = intval($request->get_param('page')) ?: 1;
+    $bgmList = new \Sakura\API\BangumiList();
+    return $bgmList->get_bgm_items($userID, $page);
 }
 
-function bgm_bilibili()
+function bgm_bilibili(WP_REST_Request $request)
 {
-    $response = null;
-    if (!check_ajax_referer('wp_rest', '_wpnonce', false)) {
+    if (!sakura_verify_rest_request_nonce($request)) {
         $output = array(
             'status' => 403,
             'success' => false,
             'message' => 'Unauthorized client.'
         );
-        $response = new WP_REST_Response($output, 403);
-    } else {
-        $page = $_GET["page"] ?: 2;
-        $bgm = new \Sakura\API\Bilibili();
-        $html = preg_replace("/\s+|\n+|\r/", ' ', $bgm->get_bgm_items($page));
-        $response = new WP_REST_Response($html, 200);
+        return new WP_REST_Response($output, 403);
     }
-    return $response;
+    $page = intval($request->get_param('page')) ?: 2;
+    $bgm = new \Sakura\API\Bilibili();
+    $html = preg_replace("/\s+|\n+|\r/", ' ', $bgm->get_bgm_items($page));
+    return new WP_REST_Response($html, 200);
 }
 
-function bfv_bilibili()
+function bfv_bilibili(WP_REST_Request $request)
 {
-    $response = null;
-    if (!check_ajax_referer('wp_rest', '_wpnonce', false)) {
+    if (!sakura_verify_rest_request_nonce($request)) {
         $output = array(
             'status' => 403,
             'success' => false,
             'message' => 'Unauthorized client.'
         );
-        $response = new WP_REST_Response($output, 403);
-    } else {
-        $page = $_GET["page"] ?: 2;
-        $bgm = new \Sakura\API\Bilibili();
-        $html = preg_replace("/\s+|\n+|\r/", ' ', $bgm->get_bfv_items($page));
-        $response = new WP_REST_Response($html, 200);
+        return new WP_REST_Response($output, 403);
     }
-    return $response;
+    $page = intval($request->get_param('page')) ?: 2;
+    $bgm = new \Sakura\API\Bilibili();
+    $html = preg_replace("/\s+|\n+|\r/", ' ', $bgm->get_bfv_items($page));
+    return new WP_REST_Response($html, 200);
 }
 
-function steam_library ($request)
+function steam_library(WP_REST_Request $request)
 {
-    if (!check_ajax_referer('wp_rest', '_wpnonce', false)) {
+    if (!sakura_verify_rest_request_nonce($request)) {
         $response = array(
             'status' => 418,
             'success' => false,
             'message' => 'Unauthorized client.'
         );
         return new WP_REST_Response($response, 418);
-    } else {
-        $page = $request->get_param('page') ?: 1;
-        $SteamList = new \Sakura\API\Steam();
     }
-    return $SteamList->get_steam_items((int)$page);
+    $page = intval($request->get_param('page')) ?: 1;
+    $SteamList = new \Sakura\API\Steam();
+    return $SteamList->get_steam_items($page);
 }
 
 function favlist_bilibili(WP_REST_Request $request)
 {
-    // 使用 WP_REST_Request 参数而不是直接访问 $_GET
-    if (!check_ajax_referer('wp_rest', '_wpnonce', false)) {
+    if (!sakura_verify_rest_request_nonce($request)) {
         $output = array(
             'code' => 401,
             'message' => 'Unauthorized client.'
@@ -471,7 +495,7 @@ function favlist_bilibili(WP_REST_Request $request)
 
 function favlist_bilibili_folders(WP_REST_Request $request)
 {
-    if (!check_ajax_referer('wp_rest', '_wpnonce', false)) {
+    if (!sakura_verify_rest_request_nonce($request)) {
         $output = array(
             'code' => 401,
             'message' => 'Unauthorized client.'
@@ -524,15 +548,18 @@ function favlist_bilibili_folders(WP_REST_Request $request)
     }
 }
 
-function meting_aplayer()
+function meting_aplayer(WP_REST_Request $request)
 {
-    $type = $_GET['type'];
-    $id = $_GET['id'];
-    if (in_array('_wpnonce', $_GET))
-        $wpnonce = $_GET['_wpnonce'];
-    if (in_array('meting_nonce', $_GET))
-        $meting_nonce = $_GET['meting_nonce'];
-    if ((isset($wpnonce) && !check_ajax_referer('wp_rest', $wpnonce, false)) || (isset($meting_nonce) && !wp_verify_nonce($meting_nonce, $type . '#:' . $id))) {
+    $type = sanitize_text_field($request->get_param('type'));
+    $id = sanitize_text_field($request->get_param('id'));
+    $wpnonce = sanitize_text_field($request->get_param('_wpnonce')) ?: null;
+    $meting_nonce = sanitize_text_field($request->get_param('meting_nonce')) ?: null;
+
+    // 必须提供至少一个有效 nonce，否则拒绝
+    $wpnonce_valid = $wpnonce && wp_verify_nonce($wpnonce, 'wp_rest');
+    $meting_nonce_valid = $meting_nonce && wp_verify_nonce($meting_nonce, $type . '#:' . $id);
+
+    if (!$wpnonce_valid && !$meting_nonce_valid) {
         $output = array(
             'status' => 403,
             'success' => false,
@@ -553,7 +580,7 @@ function meting_aplayer()
         } else {
             $response = new WP_REST_Response();
             $response->set_status(301);
-            $response->header('Location', $data);
+            $response->header('Location', esc_url_raw($data));
         }
     }
     return $response;

--- a/inc/article-highlight.php
+++ b/inc/article-highlight.php
@@ -231,11 +231,12 @@ function get_image_theme_color($input) {
                  . (isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '');
 
         error_log('编码结果为' . $input);
-        if (function_exists('wp_get_remote_content')) {
-            $image_data = wp_get_remote_content($input);
-        } else {
-            $image_data = file_get_contents($input);
+        $remote_response = wp_remote_get(esc_url_raw($input), array('timeout' => 10));
+        if (is_wp_error($remote_response) || wp_remote_retrieve_response_code($remote_response) !== 200) {
+            error_log('远程获取图片失败');
+            return false;
         }
+        $image_data = wp_remote_retrieve_body($remote_response);
     } else {
         if (file_exists($input)) {
             $image_data = file_get_contents($input);

--- a/inc/cache_settings.php
+++ b/inc/cache_settings.php
@@ -135,7 +135,7 @@ function sakurairo_cache_setting_update() {
         set_transient('steam_cache_duration', $steam_duration, DAY_IN_SECONDS * 30);
 
         // 重定向
-        wp_redirect(add_query_arg(['page' => 'sakurairo_cache_setting', 'updated' => 'true'], admin_url('admin.php')));
+        wp_safe_redirect(esc_url_raw(add_query_arg(['page' => 'sakurairo_cache_setting', 'updated' => 'true'], admin_url('admin.php'))));
         exit;
     }
 }

--- a/inc/categories-images.php
+++ b/inc/categories-images.php
@@ -145,8 +145,9 @@ function z_script() {
 add_action('edit_term','z_save_taxonomy_image');
 add_action('create_term','z_save_taxonomy_image');
 function z_save_taxonomy_image($term_id) {
-    if(isset($_POST['taxonomy_image']))
-        update_option('z_taxonomy_image'.$term_id, $_POST['taxonomy_image'], NULL);
+    if (isset($_POST['taxonomy_image']) && current_user_can('manage_categories')) {
+        update_option('z_taxonomy_image'.$term_id, esc_url_raw(wp_unslash($_POST['taxonomy_image'])), NULL);
+    }
 }
 
 // 附件地址

--- a/inc/chatgpt/aigc-manage.php
+++ b/inc/chatgpt/aigc-manage.php
@@ -12,9 +12,9 @@ function get_chatgpt_api_info(){?>
             <h2><?php _e('System Information', 'sakurairo'); ?></h2>
             <p><strong><?php _e('ChatGPT API Settings Status', 'sakurairo'); ?></strong></p>
             <pre style="background:#eee; padding:10px; overflow:auto;">
-<?php _e('API Endpoint: ', 'sakurairo'); ?><?php echo iro_opt('chatgpt_endpoint', __('Not set', 'sakurairo')); ?>
-<?php _e('API Key: ', 'sakurairo'); ?><?php echo empty(iro_opt('chatgpt_access_token')) ? __('Not set', 'sakurairo') : __('Set (Length: ', 'sakurairo') . strlen(iro_opt('chatgpt_access_token')) . ')'; ?>
-<?php _e('Model: ', 'sakurairo'); ?><?php echo iro_opt('chatgpt_model', __('Not set', 'sakurairo')); ?>
+<?php _e('API Endpoint: ', 'sakurairo'); ?><?php echo esc_html(iro_opt('chatgpt_endpoint', __('Not set', 'sakurairo'))); ?>
+<?php _e('API Key: ', 'sakurairo'); ?><?php echo empty(iro_opt('chatgpt_access_token')) ? esc_html__('Not set', 'sakurairo') : esc_html(__('Set (Length: ', 'sakurairo') . strlen(iro_opt('chatgpt_access_token')) . ')'); ?>
+<?php _e('Model: ', 'sakurairo'); ?><?php echo esc_html(iro_opt('chatgpt_model', __('Not set', 'sakurairo'))); ?>
             </pre>
         </div>
         <?php
@@ -43,7 +43,7 @@ function render_annotations_admin_page() {
     $message = '';
     $message_type = '';
     
-    if (isset($_POST['generate_annotations']) && isset($_POST['post_id']) && check_admin_referer('iro_generate_annotations')) {
+    if (isset($_POST['generate_annotations']) && isset($_POST['post_id']) && current_user_can('manage_options') && check_admin_referer('iro_generate_annotations')) {
         $post_id = intval($_POST['post_id']);
         $result = generate_annotations_for_post($post_id);
         
@@ -54,12 +54,12 @@ function render_annotations_admin_page() {
             $message = __('Failed to generate annotations. Please check API settings or view error logs.', 'sakurairo');
             $message_type = 'error';
         }
-    } elseif (isset($_POST['delete_annotations']) && isset($_POST['post_id']) && check_admin_referer('iro_generate_annotations')) {
+    } elseif (isset($_POST['delete_annotations']) && isset($_POST['post_id']) && current_user_can('manage_options') && check_admin_referer('iro_generate_annotations')) {
         $post_id = intval($_POST['post_id']);
         delete_post_meta($post_id, 'iro_chatgpt_annotations');
         $message = __('Annotations for the post have been deleted.', 'sakurairo');
         $message_type = 'warning';
-    } elseif (isset($_POST['test_save']) && isset($_POST['post_id']) && check_admin_referer('iro_generate_annotations')) {
+    } elseif (isset($_POST['test_save']) && isset($_POST['post_id']) && current_user_can('manage_options') && check_admin_referer('iro_generate_annotations')) {
         $post_id = intval($_POST['post_id']);
         $test_data = array(
             __('Example Term', 'sakurairo') => __('This is a example explanation', 'sakurairo')
@@ -107,8 +107,8 @@ function render_annotations_admin_page() {
         <h1><?php _e('Article Annotations Management', 'sakurairo'); ?></h1>
         
         <?php if (!empty($message)): ?>
-            <div class="notice notice-<?php echo $message_type; ?> is-dismissible">
-                <p><?php echo $message; ?></p>
+            <div class="notice notice-<?php echo esc_attr($message_type); ?> is-dismissible">
+                <p><?php echo wp_kses_post($message); ?></p>
             </div>
         <?php endif; 
         get_chatgpt_api_info();
@@ -141,7 +141,7 @@ function render_annotations_admin_page() {
                             <select name="post_id" id="post_id" required>
                                 <option value=""><?php _e('-- Select Post --', 'sakurairo'); ?></option>
                                 <?php foreach ($all_posts as $p): ?>
-                                    <option value="<?php echo $p->ID; ?>"><?php echo $p->post_title; ?> (ID: <?php echo $p->ID; ?>)</option>
+                                    <option value="<?php echo esc_attr($p->ID); ?>"><?php echo esc_html($p->post_title); ?> (ID: <?php echo esc_html($p->ID); ?>)</option>
                                 <?php endforeach; ?>
                             </select>
                         </td>
@@ -177,17 +177,17 @@ function render_annotations_admin_page() {
                             ?>
                             <tr>
                                 <td>
-                                    <a href="<?php echo get_permalink($post->ID); ?>" target="_blank">
-                                        <?php echo $post->post_title; ?>
+                                    <a href="<?php echo esc_url(get_permalink($post->ID)); ?>" target="_blank">
+                                        <?php echo esc_html($post->post_title); ?>
                                     </a>
                                 </td>
-                                <td><?php echo $annotation_count; ?></td>
+                                <td><?php echo esc_html($annotation_count); ?></td>
                                 <td>
-                                    <a href="#" class="view-annotations" data-post-id="<?php echo $post->ID; ?>"><?php _e('View Annotations', 'sakurairo'); ?></a> | 
-                                    <a href="<?php echo get_edit_post_link($post->ID); ?>" target="_blank"><?php _e('Edit Post', 'sakurairo'); ?></a> | 
+                                    <a href="#" class="view-annotations" data-post-id="<?php echo esc_attr($post->ID); ?>"><?php _e('View Annotations', 'sakurairo'); ?></a> | 
+                                    <a href="<?php echo esc_url(get_edit_post_link($post->ID)); ?>" target="_blank"><?php _e('Edit Post', 'sakurairo'); ?></a> | 
                                     <form method="post" style="display:inline;">
                                         <?php wp_nonce_field('iro_generate_annotations'); ?>
-                                        <input type="hidden" name="post_id" value="<?php echo $post->ID; ?>">
+                                        <input type="hidden" name="post_id" value="<?php echo esc_attr($post->ID); ?>">
                                         <input type="hidden" name="debug" value="1">
                                         <button type="submit" name="debug_annotations" class="button-link"><?php _e('Debug Information', 'sakurairo'); ?></button>
                                     </form>
@@ -201,7 +201,7 @@ function render_annotations_admin_page() {
         
         <?php
         // 处理调试请求
-        if (isset($_POST['debug_annotations']) && isset($_POST['post_id']) && check_admin_referer('iro_generate_annotations')) {
+        if (isset($_POST['debug_annotations']) && isset($_POST['post_id']) && current_user_can('manage_options') && check_admin_referer('iro_generate_annotations')) {
             $post_id = intval($_POST['post_id']);
             $post = get_post($post_id);
             
@@ -601,7 +601,7 @@ function render_summary_admin_page() {
     $message = '';
     $message_type = '';
     
-    if (isset($_POST['generate_summary']) && isset($_POST['post_id']) && check_admin_referer('iro_generate_summary')) {
+    if (isset($_POST['generate_summary']) && isset($_POST['post_id']) && current_user_can('manage_options') && check_admin_referer('iro_generate_summary')) {
         $post_id = intval($_POST['post_id']);
         $result = generate_post_summary(get_post($post_id));
         remove_action('save_post_post', 'generate_post_summary'); // 防止无限循环
@@ -614,12 +614,12 @@ function render_summary_admin_page() {
             $message = __('Failed to generate summary. Please check API settings or view error logs.', 'sakurairo') . $result;
             $message_type = 'error';
         }
-    } elseif (isset($_POST['delete_summary']) && isset($_POST['post_id']) && check_admin_referer('iro_generate_summary')) {
+    } elseif (isset($_POST['delete_summary']) && isset($_POST['post_id']) && current_user_can('manage_options') && check_admin_referer('iro_generate_summary')) {
         $post_id = intval($_POST['post_id']);
         delete_post_meta($post_id, 'ai_summon_excerpt');
         $message = __('Summary for the post has been deleted.', 'sakurairo');
         $message_type = 'warning';
-    } elseif (isset($_POST['test_save']) && isset($_POST['post_id']) && check_admin_referer('iro_generate_summary')) {
+    } elseif (isset($_POST['test_save']) && isset($_POST['post_id']) && current_user_can('manage_options') && check_admin_referer('iro_generate_summary')) {
         $post_id = intval($_POST['post_id']);
         $test_data = __('This is a test summary content.', 'sakurairo');
         
@@ -652,8 +652,8 @@ function render_summary_admin_page() {
         <h1><?php _e('Article Summary Management', 'sakurairo'); ?></h1>
         
         <?php if (!empty($message)): ?>
-            <div class="notice notice-<?php echo $message_type; ?> is-dismissible">
-                <p><?php echo $message; ?></p>
+            <div class="notice notice-<?php echo esc_attr($message_type); ?> is-dismissible">
+                <p><?php echo wp_kses_post($message); ?></p>
             </div>
         <?php endif; 
         get_chatgpt_api_info();
@@ -685,7 +685,7 @@ function render_summary_admin_page() {
                             <select name="post_id" id="post_id" required>
                                 <option value=""><?php _e('-- Select Post --', 'sakurairo'); ?></option>
                                 <?php foreach ($all_posts as $p): ?>
-                                    <option value="<?php echo $p->ID; ?>"><?php echo $p->post_title; ?> (ID: <?php echo $p->ID; ?>)</option>
+                                    <option value="<?php echo esc_attr($p->ID); ?>"><?php echo esc_html($p->post_title); ?> (ID: <?php echo esc_html($p->ID); ?>)</option>
                                 <?php endforeach; ?>
                             </select>
                         </td>
@@ -721,17 +721,17 @@ function render_summary_admin_page() {
                             ?>
                             <tr>
                                 <td>
-                                    <a href="<?php echo get_permalink($post->ID); ?>" target="_blank">
-                                        <?php echo $post->post_title; ?>
+                                    <a href="<?php echo esc_url(get_permalink($post->ID)); ?>" target="_blank">
+                                        <?php echo esc_html($post->post_title); ?>
                                     </a>
                                 </td>
                                 <td><?php echo esc_html($preview); ?></td>
                                 <td>
-                                    <a href="#" class="view-summary" data-post-id="<?php echo $post->ID; ?>"><?php _e('View/Edit Summary', 'sakurairo'); ?></a> | 
-                                    <a href="<?php echo get_edit_post_link($post->ID); ?>" target="_blank"><?php _e('Edit Post', 'sakurairo'); ?></a> | 
+                                    <a href="#" class="view-summary" data-post-id="<?php echo esc_attr($post->ID); ?>"><?php _e('View/Edit Summary', 'sakurairo'); ?></a> | 
+                                    <a href="<?php echo esc_url(get_edit_post_link($post->ID)); ?>" target="_blank"><?php _e('Edit Post', 'sakurairo'); ?></a> | 
                                     <form method="post" style="display:inline;">
                                         <?php wp_nonce_field('iro_generate_summary'); ?>
-                                        <input type="hidden" name="post_id" value="<?php echo $post->ID; ?>">
+                                        <input type="hidden" name="post_id" value="<?php echo esc_attr($post->ID); ?>">
                                         <button type="submit" name="delete_summary" class="button-link" onclick="return confirm('<?php _e('Are you sure you want to delete this summary?', 'sakurairo'); ?>');">
                                             <?php _e('Delete', 'sakurairo'); ?>
                                         </button>

--- a/inc/classes/QQ.php
+++ b/inc/classes/QQ.php
@@ -5,18 +5,23 @@ namespace Sakura\API;
 class QQ
 {
     public static function get_qq_info($qq) {
-        $get_info = file_get_contents('https://api.qjqq.cn/api/qqinfo?qq=' . $qq);
-        $name = json_decode($get_info, true);
-        if ($name) {
-            if ($name['code'] == 200){
-                $output = array(
-                    'status' => 200,
-                    'success' => true,
-                    'message' => 'success',
-                    'avatar' => 'https://q2.qlogo.cn/headimg_dl?dst_uin=' . $qq . '&spec=100',
-                    'name' => $name['name'],
-                );
-            }
+        $response = wp_remote_get('https://api.qjqq.cn/api/qqinfo?qq=' . urlencode($qq), array('timeout' => 5));
+        if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+            return array(
+                'status' => 404,
+                'success' => false,
+                'message' => 'QQ number not exist.'
+            );
+        }
+        $name = json_decode(wp_remote_retrieve_body($response), true);
+        if ($name && isset($name['code']) && $name['code'] == 200) {
+            $output = array(
+                'status' => 200,
+                'success' => true,
+                'message' => 'success',
+                'avatar' => 'https://q2.qlogo.cn/headimg_dl?dst_uin=' . $qq . '&spec=100',
+                'name' => isset($name['name']) ? $name['name'] : '',
+            );
         } else {
             $output = array(
                 'status' => 404,
@@ -29,12 +34,35 @@ class QQ
 
     public static function get_qq_avatar($encrypted) {
         global $sakura_privkey;
-        if (isset($encrypted)) {
-            $iv = str_repeat($sakura_privkey, 2);
-            $encrypted = base64_decode(urldecode($encrypted));
-            $qq_number = openssl_decrypt($encrypted, 'aes-128-cbc', $sakura_privkey, 0, $iv);
-            preg_match('/^\d{3,}$/', $qq_number, $matches);
-            return 'https://q2.qlogo.cn/headimg_dl?dst_uin=' . $matches[0] . '&spec=100';
+        if (!isset($sakura_privkey) || empty($encrypted)) {
+            return false;
         }
+
+        // 解码：urldecode → base64_decode → 分离 IV 和密文
+        $decoded = base64_decode(urldecode($encrypted));
+        if ($decoded === false) {
+            return false;
+        }
+
+        $iv_length = openssl_cipher_iv_length('aes-128-cbc');
+        if (strlen($decoded) <= $iv_length) {
+            return false;
+        }
+
+        // 提取前 16 字节作为 IV，与 change_avatar 加密端一致
+        $iv = substr($decoded, 0, $iv_length);
+        $ciphertext = substr($decoded, $iv_length);
+
+        $qq_number = openssl_decrypt($ciphertext, 'aes-128-cbc', $sakura_privkey, 0, $iv);
+        if ($qq_number === false) {
+            return false;
+        }
+
+        // 验证解密结果为纯数字 QQ 号
+        if (!preg_match('/^\d{3,}$/', $qq_number)) {
+            return false;
+        }
+
+        return 'https://q2.qlogo.cn/headimg_dl?dst_uin=' . $qq_number . '&spec=100';
     }
 }

--- a/inc/classes/gallery.php
+++ b/inc/classes/gallery.php
@@ -189,8 +189,8 @@ class gallery
     }
 
     //获取图片
-    public function get_image() {
-        $imgParam = isset($_GET['img']) ? sanitize_text_field($_GET['img']) : '';
+    public function get_image(\WP_REST_Request $request) {
+        $imgParam = sanitize_text_field($request->get_param('img')) ?: '';
         $imageList = json_decode(file_get_contents($this->image_list), true);
 
         if (empty($imageList)) {
@@ -224,7 +224,7 @@ class gallery
 
             $random_image = wp_get_upload_dir()['baseurl'] . $random_image;
 
-            wp_redirect($random_image, 302);
+            wp_safe_redirect(esc_url_raw($random_image), 302);
             exit;
         } else {
             return $error;

--- a/inc/dash-scheme.php
+++ b/inc/dash-scheme.php
@@ -9,28 +9,32 @@
 header("Content-type: text/css; charset: UTF-8");
 #header('Access-Control-Allow-Origin: *');
 
+// 此文件作为独立 CSS 直接输出，未经 WP 引导，不可使用 WP 函数
 function _get($str){
-    $val = !empty($_GET[$str]) ? $_GET[$str] : null;
+    // 原生 PHP 净化：去除斜杠与 HTML 标签
+    // 防御数组型参数（如 ?color_1[]=x），避免 strip_tags()/stripslashes() 在 PHP 8 抛出 TypeError
+    if (empty($_GET[$str]) || is_array($_GET[$str])) {
+        return null;
+    }
+    $val = strip_tags(stripslashes($_GET[$str]));
     return $val;
 }
 
-if(_get('color_1')==NULL) {
-	$color_1="#000";
-} else {
-	$color_1="#"._get('color_1');
+/**
+ * Validate and sanitize a hex color value.
+ */
+function _sanitize_hex_color($color, $default = '#000') {
+    if (empty($color)) return $default;
+    $color = ltrim($color, '#');
+    if (!preg_match('/^[a-fA-F0-9]{3}$|^[a-fA-F0-9]{6}$/', $color)) {
+        return $default;
+    }
+    return '#' . $color;
 }
 
-if(_get('color_2')==NULL) {
-	$color_2="#000";
-} else {
-	$color_2="#"._get('color_2');
-}
-
-if(_get('color_3')==NULL) {
-	$color_3="#ff6496";
-} else {
-	$color_3="#"._get('color_3');
-}
+$color_1 = _sanitize_hex_color(_get('color_1'), '#000');
+$color_2 = _sanitize_hex_color(_get('color_2'), '#000');
+$color_3 = _sanitize_hex_color(_get('color_3'), '#ff6496');
 
 // Convert hex to rgba with higher transparency values
 function hex2rgba($color, $opacity = 1) {
@@ -80,7 +84,15 @@ $color_3_40 = hex2rgba($color_3, 0.40);
 if(_get('rules')==NULL) {
 	$rules="";
 } else {
-	$rules=urldecode(_get('rules'));
+	// 使用原生 strip_tags（此文件无 WP 引导）
+	$rules = strip_tags(urldecode(_get('rules')));
+	// Remove dangerous CSS functions and imports
+	$rules = preg_replace('/@import/i', '/* blocked */', $rules);
+	$rules = preg_replace('/expression\s*\(/i', '/* blocked */', $rules);
+	$rules = preg_replace('/javascript\s*:/i', '/* blocked */', $rules);
+	$rules = preg_replace('/-moz-binding\s*:/i', '/* blocked */', $rules);
+	$rules = preg_replace('/behavior\s*:/i', '/* blocked */', $rules);
+	$rules = preg_replace('/url\s*\(\s*[\'"]?\s*data\s*:/i', '/* blocked */', $rules);
 }
 
 ?>

--- a/inc/link-status.php
+++ b/inc/link-status.php
@@ -321,13 +321,13 @@ add_filter('manage_edit-link_category_sortable_columns', function($columns) {
 });
 
 add_action('created_link_category', function($term_id) {
-    if (isset($_POST['term_priority'])) {
+    if (isset($_POST['term_priority']) && current_user_can('manage_categories')) {
         update_term_meta($term_id, 'term_priority', intval($_POST['term_priority']));
     }
 });
 
 add_action('edited_link_category', function($term_id) {
-    if (isset($_POST['term_priority'])) {
+    if (isset($_POST['term_priority']) && current_user_can('manage_categories')) {
         update_term_meta($term_id, 'term_priority', intval($_POST['term_priority']));
     }
 });

--- a/inc/theme-plus.php
+++ b/inc/theme-plus.php
@@ -144,7 +144,6 @@ add_filter( 'comment_text' , 'comment_add_at', 20, 2);
 /*
  * Ajax评论
  */
-if ( version_compare( $GLOBALS['wp_version'], '4.4-alpha', '<' ) ) { wp_die(__('Please upgrade wordpress to version 4.4+','sakurairo')); }/*请升级到4.4以上版本*/
 // 提示
 if(!function_exists('siren_ajax_comment_err')) {
     function siren_ajax_comment_err($t) {
@@ -166,15 +165,18 @@ function comment_captcha(){
     return true;
   }
   if (iro_opt('comment_captcha_select') == "iro_captcha") {
-      if (!(isset($_POST['captcha']) && !empty(trim($_POST['captcha'])))) {
+      $captcha = isset($_POST['captcha']) ? sanitize_text_field(wp_unslash($_POST['captcha'])) : '';
+      $timestamp = isset($_POST['timestamp']) ? sanitize_text_field(wp_unslash($_POST['timestamp'])) : '';
+      $captcha_id = isset($_POST['id']) ? sanitize_text_field(wp_unslash($_POST['id'])) : '';
+      if (empty(trim($captcha))) {
           return siren_ajax_comment_err(__('Please fill in the captcha answer','sakurairo'));
       }
-      if (!isset($_POST['timestamp']) || !isset($_POST['id']) || !preg_match('/^[\w$.\/]+$/', $_POST['id']) || !ctype_digit($_POST['timestamp'])) {
+      if (empty($timestamp) || empty($captcha_id) || !preg_match('/^[\w$.\/]+$/', $captcha_id) || !ctype_digit($timestamp)) {
           return siren_ajax_comment_err(__('Have you modified the captcha code data? Or refresh the captcha and try again?','sakurairo'));
       }
       include_once( get_template_directory() . '/inc/classes/Captcha.php');
       $img = new Sakura\API\Captcha;
-      $check = $img->check_captcha($_POST['captcha'], $_POST['timestamp'], $_POST['id']);
+      $check = $img->check_captcha($captcha, $timestamp, $captcha_id);
       if ($check['code'] == 5) {
           return true;
       }
@@ -209,6 +211,7 @@ add_action('pre_comment_on_post', 'comment_captcha');
 // 评论提交
 if(!function_exists('siren_ajax_comment_callback')) {
     function siren_ajax_comment_callback(){
+      check_ajax_referer('sakurairo_ajax_comment', 'sakurairo_comment_nonce');
       $comment = wp_handle_comment_submission( wp_unslash( $_POST ) );
       if( is_wp_error( $comment ) ) {
         $data = $comment->get_error_data();
@@ -291,7 +294,7 @@ function the_headPattern(){
   if(!is_home() && $full_image_url) : ?>
   <div class="pattern-center-blank"></div>
   <div class="pattern-center <?php if(is_single()){echo $center;} ?>">
-    <div class="pattern-attachment bg lazyload" style="background-image: url(<?php echo iro_opt('load_out_svg'); ?>)" data-src="<?php echo $full_image_url; ?>"> </div>
+    <div class="pattern-attachment bg lazyload" style="background-image: url(<?php echo esc_url(iro_opt('load_out_svg')); ?>)" data-src="<?php echo esc_url($full_image_url); ?>"> </div>
     <header class="pattern-header <?php if(is_single()){echo $header;} ?>"><?php echo $t; ?></header>
   </div>
   <?php else :

--- a/inc/theme-plus.php
+++ b/inc/theme-plus.php
@@ -132,7 +132,7 @@ function var_post_theme_color($id = null) {
 function comment_add_at( $comment_text, $comment = '') {
   if( isset($comment->comment_parent) && $comment->comment_parent > 0) {
       if(substr($comment_text, 0, 3) === "<p>") 
-        $comment_text = str_replace(substr($comment_text, 0, 3), '<p><a href="#comment-' . $comment->comment_parent . '" class="comment-at">@'.get_comment_author( $comment->comment_parent ) . '</a>&nbsp;', $comment_text);
+        $comment_text = preg_replace('/<p>/', '<p><a href="#comment-' . $comment->comment_parent . '" class="comment-at">@' . get_comment_author($comment->comment_parent) . '</a>&nbsp;', $comment_text, 1);
       else
         $comment_text = '<a href="#comment-' . $comment->comment_parent . '" class="comment-at">@'.get_comment_author( $comment->comment_parent ) . '</a>&nbsp;' . $comment_text;
   }

--- a/layouts/imgbox.php
+++ b/layouts/imgbox.php
@@ -60,15 +60,15 @@ $print_social_zone = function() use ($all_opt): void {
         foreach ($social_icons_with_inner as $icon_data):
             ob_start(); ?>
             <li class="socialIconWithInner">
-                <a href="javascript:void(0);" title="<?= strtolower($icon_data['icon']) ?>" onclick="<?= $icon_data['action'] ?>">
+                <a href="javascript:void(0);" title="<?= esc_attr(strtolower($icon_data['icon'])) ?>" onclick="<?= esc_attr($icon_data['action']) ?>">
                     <?php if (iro_opt('social_display_icon') === 'display_icon/remix_iconfont'): ?>
                         <i class="remix_social icon-<?= esc_attr($icon_data['icon']) ?>"></i>
                     <?php else: ?>
-                        <img loading="lazy" src="<?= iro_opt('vision_resource_basepath') . iro_opt('social_display_icon') . '/' . esc_attr($icon_data['icon']) . '.webp' ?>" />
+                        <img loading="lazy" src="<?= esc_url(iro_opt('vision_resource_basepath') . iro_opt('social_display_icon') . '/' . $icon_data['icon'] . '.webp') ?>" />
                     <?php endif; ?>
                 </a>
             <div class="inner">
-                <?= $icon_data['inner'] ?>
+                <?= wp_kses_post($icon_data['inner']) ?>
             </div>
             </li>
         <?php
@@ -82,11 +82,11 @@ $print_social_zone = function() use ($all_opt): void {
             $img_url = $value['img'] ?? (iro_opt('vision_resource_basepath').iro_opt('social_display_icon').'/' . ($value['icon'] ?? $key) . '.webp');
             $title = $value['title'] ?? $key;
             ob_start(); ?>
-            <li><a href="<?= $value['link']; ?>" target="_blank" class="social-<?= $value['class'] ?? $key ?>" title="<?= $title ?>">
+            <li><a href="<?= esc_url($value['link']); ?>" target="_blank" class="social-<?= esc_attr($value['class'] ?? $key) ?>" title="<?= esc_attr($title) ?>">
                 <?php if (iro_opt('social_display_icon') === 'display_icon/remix_iconfont'): ?>
                     <i class="remix_social icon-<?= $key ?>"></i>
                 <?php else: ?>
-                    <img alt="<?= $title ?>" loading="lazy" src="<?= $img_url ?>" />
+                    <img alt="<?= esc_attr($title) ?>" loading="lazy" src="<?= esc_url($img_url) ?>" />
                 <?php endif; ?>
             </a></li>
         <?php
@@ -101,7 +101,7 @@ $print_social_zone = function() use ($all_opt): void {
             <?php if (iro_opt('social_display_icon') === 'display_icon/remix_iconfont'): ?>
                 <i class="remix_social icon-mail"></i>
             <?php else: ?>
-                <img loading="lazy" alt="E-mail" src="<?php echo iro_opt('vision_resource_basepath').iro_opt('social_display_icon').'/' . 'mail.webp'; ?>" />
+                <img loading="lazy" alt="E-mail" src="<?php echo esc_url(iro_opt('vision_resource_basepath').iro_opt('social_display_icon').'/' . 'mail.webp'); ?>" />
             <?php endif; ?>
         </a></li>
     <?php
@@ -334,7 +334,7 @@ $print_social_zone = function() use ($all_opt): void {
                     <?= iro_opt('signature_typing_json', ''); ?>
                     </script>
                     <?php endif; ?>
-                    <p><?php echo iro_opt('signature_text', 'Hi, Mashiro?'); ?></p>
+                    <p><?php echo esc_html(iro_opt('signature_text', 'Hi, Mashiro?')); ?></p>
                     <?php if (iro_opt('infor_bar_style') === 'v2') : ?>
                         <div class="top-social_v2">
                             <?php $print_social_zone(); ?>

--- a/search.php
+++ b/search.php
@@ -37,7 +37,7 @@ get_header(); ?>
     }
 
     // 获取当前查询参数中的content_type内容
-    $content_types = isset($_GET['content_type']) ? explode(',', $_GET['content_type']) : $default_checked;
+    $content_types = isset($_GET['content_type']) ? array_map('sanitize_key', explode(',', wp_unslash($_GET['content_type']))) : $default_checked;
 
     // 搜索页标题
     if (!iro_opt('patternimg') || !get_random_bg_url()) : ?>

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ Theme URI: https://github.com/mirai-mamori/Sakurairo
 Author: Created by Fuukei
 Author URI: https://docs.fuukei.org/
 Description: A WordPress theme that is built with AI-assisted reading features, colorful, user-friendly, well-rounded, and rich in functionalities. (Based on Theme Sakura)
-Version: 3.0.10
+Version: 3.0.11
 Tested up to: 6.8
 Requires at least: 6.0
 Requires PHP: 8.0

--- a/tpl/content-none.php
+++ b/tpl/content-none.php
@@ -32,7 +32,7 @@
 				$postid = $post->ID;
 				$title = $post->post_title;
 				?>
-				<li><a href="<?php echo get_permalink($postid); ?>" title="<?php echo $title ?>"><?php echo $title ?></a> </li>
+				<li><a href="<?php echo esc_url(get_permalink($postid)); ?>" title="<?php echo esc_attr($title); ?>"><?php echo esc_html($title); ?></a> </li>
 				<?php } ?>
 			</ul>
 			</div>


### PR DESCRIPTION
# 问题

在测试评论 Markdown 功能时，发现这样一个现象，评论中出现了两次“@”：

<img width="1353" height="794" alt="5eec8cb7802e7c1debe55ecc195c76d6" src="https://github.com/user-attachments/assets/fd8a84a2-a6e1-43ea-91eb-a491121a5653" />

该评论内容的结构是：正文 + 标题 + 正文。显然两处正文之前各自添加了一次”@“。

# 溯源

子评论最前面会带上“@父评论作者”，这个功能在 `inc/theme-plus.php` 中实现：

```php
/*
 * 评论添加@
 */
function comment_add_at( $comment_text, $comment = '') {
  if( isset($comment->comment_parent) && $comment->comment_parent > 0) {
      if(substr($comment_text, 0, 3) === "<p>") 
        $comment_text = str_replace(substr($comment_text, 0, 3), '<p><a href="#comment-' . $comment->comment_parent . '" class="comment-at">@'.get_comment_author( $comment->comment_parent ) . '</a>&nbsp;', $comment_text);
      else
        $comment_text = '<a href="#comment-' . $comment->comment_parent . '" class="comment-at">@'.get_comment_author( $comment->comment_parent ) . '</a>&nbsp;' . $comment_text;
  }
  return $comment_text;
}
```

其中，`if(substr($comment_text, 0, 3) === "<p>")` 当内容以 `<p>` 开头时，会通过 `str_replace` 替换全文所有的 `<p>`，这导致如果评论内容中包含多个段落，那么就会产生多个”@“，而我们仅仅需要在评论开头添加”@“。

# 解决

因此，我们需要把这里的全文匹配替换修复为只替换第一次匹配。

```diff
/*
 * 评论添加@
 */
function comment_add_at( $comment_text, $comment = '') {
  if( isset($comment->comment_parent) && $comment->comment_parent > 0) {
      if(substr($comment_text, 0, 3) === "<p>") 
-         $comment_text = str_replace(substr($comment_text, 0, 3), '<p><a href="#comment-' . $comment->comment_parent . '" class="comment-at">@'.get_comment_author( $comment->comment_parent ) . '</a>&nbsp;', $comment_text);
+         $comment_text = preg_replace('/<p>/', '<p><a href="#comment-' . $comment->comment_parent . '" class="comment-at">@' . get_comment_author($comment->comment_parent) . '</a>&nbsp;', $comment_text, 1);
      else
        $comment_text = '<a href="#comment-' . $comment->comment_parent . '" class="comment-at">@'.get_comment_author( $comment->comment_parent ) . '</a>&nbsp;' . $comment_text;
  }
  return $comment_text;
}
```

改用 `preg_replace` 匹配替换，第 4 个参数 `1` 表示只替换 1 次。

# 测试

修复后再次测试相同结构的评论，仅有开头一次”@“，修复成功。

<img width="1290" height="519" alt="b8bb0655bf93db6bc1c22dc197fa2afc" src="https://github.com/user-attachments/assets/7965a49a-f27b-4d90-ad00-fd292020632f" />

