### PR TITLE
修复子菜单高度错误的问题

### DIFF
--- a/style.css
+++ b/style.css
@@ -679,7 +679,7 @@ blockquote:after {
   transition: all 0.4s ease-in-out;
   margin: 0;
   padding: 0;
-  height: 100%;
+  height: fit-content;
   align-items: center;
 }
 


### PR DESCRIPTION
<img width="550" height="227" alt="image" src="https://github.com/user-attachments/assets/1e331257-4ef0-4bab-8613-9e582a8ff48a" />

当子菜单使用样式height:100%时，它会继承其父容器的高度，而父容器为导航栏，会导致其高度异常

现在回退了这个修改为fit-content